### PR TITLE
Added Clinical Trial Numbers functionality

### DIFF
--- a/src/cayenne/api/v1/filter.clj
+++ b/src/cayenne/api/v1/filter.clj
@@ -12,6 +12,7 @@
             [cayenne.ids.issn :as issn]
             [cayenne.ids.orcid :as orcid]
             [cayenne.ids.doi :as doi-id]
+            [cayenne.ids.ctn :as ctn]
             [somnium.congomongo :as m]
             [clojure.string :as string]))
 
@@ -274,6 +275,7 @@
    "has-award" (existence "award_number")
    "funder-doi-asserted-by" (equality "funder_record_doi_asserted_by")
    "has-assertion" (existence "assertion_name")
+   "has-clinical-trial-number" (existence "clinical_trial_number_ctn")
    "full-text" (compound "full_text" ["type" "application" "version"]
                          :transformers {"type" util/slugify
                                         "application" util/slugify})
@@ -296,6 +298,7 @@
    "publisher-name" (equality "publisher")
    "category-name" (equality "category")
    "funder-name" (equality "funder_name")
+   "clinical-trial-number" (equality "clinical_trial_number_proxy" :transformer ctn/ctn-proxy)
    "alternative-id" (equality "supplementary_id" :transformer ids/to-supplementary-id-uri)
    "award" (compound "award" ["funder_doi" "number"]
                      :transformers {"funder_doi" (comp util/slugify fundref/normalize-to-doi-uri)}

--- a/src/cayenne/api/v1/validate.clj
+++ b/src/cayenne/api/v1/validate.clj
@@ -220,7 +220,9 @@
    :license.version version-validator
    :license.delay integer-validator
    :award.funder funder-id-validator
-   :award.number string-validator})
+   :award.number string-validator
+   :has-clinical-trial-number boolean-validator
+   :clinical-trial-number string-validator})
 
 (def deposit-filter-validators
   {:from-submission-time date-validator

--- a/src/cayenne/formats/citeproc.clj
+++ b/src/cayenne/formats/citeproc.clj
@@ -303,6 +303,6 @@
       (assoc-exists :page (->citeproc-pages solr-doc))
       (assoc-exists :funder (->citeproc-funders-merged solr-doc))
       (assoc-exists :assertion (->citeproc-assertions solr-doc))
-      (assoc-exists :clinical-trial-numbers (->clinical-trial-numbers solr-doc))
+      (assoc-exists :clinical-trial-number (->clinical-trial-numbers solr-doc))
       (merge (->citeproc-contribs solr-doc))))
 

--- a/src/cayenne/formats/citeproc.clj
+++ b/src/cayenne/formats/citeproc.clj
@@ -249,6 +249,15 @@
                (util/?> (or group-name group-label)
                         assoc :group (->citeproc-assertion-group group-name group-label)))))))
 
+(defn ->clinical-trial-numbers [solr-doc]
+  (let [ctns (get solr-doc "clinical_trial_number_ctn")
+        registries (get solr-doc "clinical_trial_number_registry")
+        types (get solr-doc "clinical_trial_number_type")]
+    (map (fn [ctn registry type]
+      (merge
+        {:clinical-trial-number ctn :registry registry}
+        (when (and type (not= type "-")) {:type type}))) ctns registries types)))
+
 (defn ->citeproc [solr-doc]
   (-> {:source (get solr-doc "source")
        :prefix (get solr-doc "owner_prefix")
@@ -294,5 +303,6 @@
       (assoc-exists :page (->citeproc-pages solr-doc))
       (assoc-exists :funder (->citeproc-funders-merged solr-doc))
       (assoc-exists :assertion (->citeproc-assertions solr-doc))
+      (assoc-exists :clinical-trial-numbers (->clinical-trial-numbers solr-doc))
       (merge (->citeproc-contribs solr-doc))))
 

--- a/src/cayenne/formats/unixref.clj
+++ b/src/cayenne/formats/unixref.clj
@@ -577,9 +577,9 @@
    (parse-item-funders-with-fundgroup item-loc)))
 
 (defn parse-clinical-trial-number [clinical-trial-number-loc]
-  (let [registry-id (or (xml/xselect1 clinical-trial-number-loc ["registry" :plain]) "-")
-        ctn-type (or (xml/xselect1 clinical-trial-number-loc ["type" :plain]) "-")
-        ctn-val (or (normalize-ctn (xml/xselect1 clinical-trial-number-loc :plain)) "-")]
+  (let [registry-id (xml/xselect1 clinical-trial-number-loc ["registry" :plain])
+        ctn-type (xml/xselect1 clinical-trial-number-loc ["type" :plain])
+        ctn-val (normalize-ctn (xml/xselect1 clinical-trial-number-loc :plain))]
     {:type :ctn :registry registry-id :ctn-type ctn-type :ctn ctn-val}))
 
 (defn parse-item-clinical-trial-numbers

--- a/src/cayenne/formats/unixref.clj
+++ b/src/cayenne/formats/unixref.clj
@@ -7,7 +7,8 @@
             [cayenne.ids.fundref :as fundref]
             [cayenne.item-tree :as itree]
             [clojure.tools.trace :as trace]
-            [taoensso.timbre :as timbre :refer [info error]])
+            [taoensso.timbre :as timbre :refer [info error]]
+            [cayenne.ids.ctn :refer [normalize-ctn]])
   (:use [cayenne.util :only [?> ?>>]])
   (:use [cayenne.ids.doi :only [to-long-doi-uri]])
   (:use [cayenne.ids.issn :only [to-issn-uri]])
@@ -575,6 +576,23 @@
    (parse-item-funders-funder-id-direct item-loc)
    (parse-item-funders-with-fundgroup item-loc)))
 
+(defn parse-clinical-trial-number [clinical-trial-number-loc]
+  (let [registry-id (or (xml/xselect1 clinical-trial-number-loc ["registry" :plain]) "-")
+        ctn-type (or (xml/xselect1 clinical-trial-number-loc ["type" :plain]) "-")
+        ctn-val (or (normalize-ctn (xml/xselect1 clinical-trial-number-loc :plain)) "-")]
+    {:type :ctn :registry registry-id :ctn-type ctn-type :ctn ctn-val}))
+
+(defn parse-item-clinical-trial-numbers
+  [item-loc]
+  (let [ctns (concat 
+               (xml/xselect item-loc 
+                            "crossmark" 
+                            "custom_metadata" 
+                            "program" 
+                            "clinical-trial-number"))
+      parsed (map parse-clinical-trial-number ctns)]
+  parsed))
+
 (def license-date-formatter (ftime/formatter "yyyy-MM-dd"))
 
 ;; some publishers are depositing dates as a date time in an unknown
@@ -670,6 +688,7 @@
       (parse-attach :component item-loc :multi parse-component-list)
       (parse-attach :institution item-loc :multi parse-institutions)
       (parse-attach :funder item-loc :multi parse-item-funders)
+      (parse-attach :clinical-trial-number item-loc :multi parse-item-clinical-trial-numbers)
       (parse-attach :author item-loc :multi (partial parse-item-contributors "author"))
       (parse-attach :editor item-loc :multi (partial parse-item-contributors "editor"))
       (parse-attach :translator item-loc :multi (partial parse-item-contributors "translator"))

--- a/src/cayenne/ids/ctn.clj
+++ b/src/cayenne/ids/ctn.clj
@@ -1,0 +1,15 @@
+(ns cayenne.ids.ctn)
+(defn normalize-ctn
+  "Normalize a CTN for display."
+  [ctn]
+  (when ctn
+    (.toLowerCase ctn)))
+
+
+(defn ctn-proxy
+  "Normalize a CTN to a proxy for search."
+  [ctn]
+  (->
+    ctn
+    (.toLowerCase)
+    (clojure.string/replace #"[^a-z0-9]" "")))

--- a/src/cayenne/tasks/solr.clj
+++ b/src/cayenne/tasks/solr.clj
@@ -462,7 +462,7 @@
          "funder_record_doi" (map (util/?fn- (comp first get-item-ids)) funders)
          "clinical_trial_number_ctn" (map :ctn clinical-trial-numbers)
          "clinical_trial_number_registry" (map :registry clinical-trial-numbers)
-         "clinical_trial_number_type" (map :ctn-type clinical-trial-numbers)
+         "clinical_trial_number_type" (map (util/?- :ctn-type) clinical-trial-numbers)
          "clinical_trial_number_proxy" (map #(-> % :ctn cayenne.ids.ctn/ctn-proxy) clinical-trial-numbers)
        }
 

--- a/src/cayenne/tasks/solr.clj
+++ b/src/cayenne/tasks/solr.clj
@@ -360,6 +360,7 @@
         full-text-resources (get-item-rel item :resource-fulltext)
         funders (get-tree-rel item :funder)
         assertions (get-tree-rel item :assertion)
+        clinical-trial-numbers (get-tree-rel item :clinical-trial-number)
         pub-date (get-earliest-pub-date item)
 
         ;; print pub date is explicit or default
@@ -458,7 +459,13 @@
          "update_date" (map #(-> (get-item-rel % :updated) first as-datetime) updates)
          "funder_record_name" (map (util/?- :name) funders)
          "funder_record_doi_asserted_by" (map (util/?- :doi-asserted-by) funders)
-         "funder_record_doi" (map (util/?fn- (comp first get-item-ids)) funders)}
+         "funder_record_doi" (map (util/?fn- (comp first get-item-ids)) funders)
+         "clinical_trial_number_ctn" (map :ctn clinical-trial-numbers)
+         "clinical_trial_number_registry" (map :registry clinical-trial-numbers)
+         "clinical_trial_number_type" (map :ctn-type clinical-trial-numbers)
+         "clinical_trial_number_proxy" (map #(-> % :ctn cayenne.ids.ctn/ctn-proxy) clinical-trial-numbers)
+       }
+
         (merge (as-assertion-list assertions))
         (merge (as-contributor-affiliation-lists contrib-details))
         (merge (as-award-compounds funders))

--- a/test/cayenne/ctn_test.clj
+++ b/test/cayenne/ctn_test.clj
@@ -1,0 +1,19 @@
+(ns cayenne.ctn-test
+  (:require [clojure.test :refer :all]
+            [cayenne.ids.ctn :refer :all]))
+
+(deftest normalize-ctn-test
+  (testing "normalize-ctn converts to lower case"
+    (is (= (normalize-ctn "ISRCTN12345") "isrctn12345"))
+    (is (= (normalize-ctn "isrctn12345") "isrctn12345"))))
+
+(deftest ctn-proxy-test
+  (testing "ctn-proxy removes non-significant characters."
+    (is (= (ctn-proxy "ISRCTN12345") (ctn-proxy "ISRCTN12345")))
+    (is (= (ctn-proxy "ISRCTN12345") (ctn-proxy "isrctn12345")))
+    (is (= (ctn-proxy "ISRCTN-12345") (ctn-proxy "ISRCTN12345")))
+    (is (= (ctn-proxy "ISRCTN___12345") (ctn-proxy "ISRCTN12345")))))
+    
+
+
+


### PR DESCRIPTION
- 'clinical-trial-numbers' in citeproc, unixref parsing
- filters 'has-clinical-trial-number' and 'clinical-trial-number'
- normalization of CTNs for searching
- tests for normalization
- added relevant fields to SOLR output
