### PR TITLE
Fix issue with more minimal peer review xml source

### DIFF
--- a/dev-resources/works/10.7287/peerj.1078v0.2/reviews/1.edn
+++ b/dev-resources/works/10.7287/peerj.1078v0.2/reviews/1.edn
@@ -1,0 +1,32 @@
+{:reference-count 0,
+ :publisher nil,
+ :content-domain {:domain []},
+ :short-container-title [],
+ :published-print {:date-parts [[2015 7 14]]},
+ :DOI "10.7287/peerj.1078v0.2/reviews/1",
+ :type "peer-review",
+ :created
+ {:date-parts [[2018 1 10]],
+  :date-time "2018-01-10T17:22:19Z",
+  :timestamp 1515604939000},
+ :source "Crossref",
+ :is-referenced-by-count 0,
+ :title
+ ["Peer Review #1 of \"Multimodal Imaging Brain Connectivity Analysis (MIBCA) toolbox (v0.2)\""],
+ :prefix "10.7287",
+ :member nil,
+ :container-title [],
+ :original-title [],
+ :deposited
+ {:date-parts [[2018 1 10]],
+  :date-time "2018-01-10T17:22:19Z",
+  :timestamp 1515604939000},
+ :score 1.0,
+ :subtitle [],
+ :short-title [],
+ :issued {:date-parts [[2015 7 14]]},
+ :references-count 0,
+ :URL "http://dx.doi.org/10.7287/peerj.1078v0.2/reviews/1",
+ :relation
+ {:is-review-of
+  [{:id-type "doi", :id "10.7717/peerj.1078", :asserted-by "subject"}]}}

--- a/dev-resources/works/?filter=from-created-date:2018.edn
+++ b/dev-resources/works/?filter=from-created-date:2018.edn
@@ -1,7 +1,34 @@
 {:facets {},
- :total-results 1,
+ :total-results 2,
  :items
- ({:institution
+ ({:reference-count 0,
+   :content-domain {:domain []},
+   :published-print {:date-parts [[2015 7 14]]},
+   :DOI "10.7287/peerj.1078v0.2/reviews/1",
+   :type "peer-review",
+   :created
+   {:date-parts [[2018 1 10]],
+    :date-time "2018-01-10T17:22:19Z",
+    :timestamp 1515604939000},
+   :source "Crossref",
+   :is-referenced-by-count 0,
+   :title
+   ["Peer Review #1 of \"Multimodal Imaging Brain Connectivity Analysis (MIBCA) toolbox (v0.2)\""],
+   :prefix "10.7287",
+   :deposited
+   {:date-parts [[2018 1 10]],
+    :date-time "2018-01-10T17:22:19Z",
+    :timestamp 1515604939000},
+   :score 1.0,
+   :issued {:date-parts [[2015 7 14]]},
+   :references-count 0,
+   :URL "http://dx.doi.org/10.7287/peerj.1078v0.2/reviews/1",
+   :relation
+   {:is-review-of
+    [{:id-type "doi",
+      :id "10.7717/peerj.1078",
+      :asserted-by "subject"}]}}
+  {:institution
    {:name "Psychoceramics Institute",
     :place ["Pittsburg, Arizona"],
     :department ["Soft furnishings"],

--- a/dev-resources/works/?filter=from-deposit-date:2018.edn
+++ b/dev-resources/works/?filter=from-deposit-date:2018.edn
@@ -1,7 +1,34 @@
 {:facets {},
- :total-results 1,
+ :total-results 2,
  :items
- ({:institution
+ ({:reference-count 0,
+   :content-domain {:domain []},
+   :published-print {:date-parts [[2015 7 14]]},
+   :DOI "10.7287/peerj.1078v0.2/reviews/1",
+   :type "peer-review",
+   :created
+   {:date-parts [[2018 1 10]],
+    :date-time "2018-01-10T17:22:19Z",
+    :timestamp 1515604939000},
+   :source "Crossref",
+   :is-referenced-by-count 0,
+   :title
+   ["Peer Review #1 of \"Multimodal Imaging Brain Connectivity Analysis (MIBCA) toolbox (v0.2)\""],
+   :prefix "10.7287",
+   :deposited
+   {:date-parts [[2018 1 10]],
+    :date-time "2018-01-10T17:22:19Z",
+    :timestamp 1515604939000},
+   :score 1.0,
+   :issued {:date-parts [[2015 7 14]]},
+   :references-count 0,
+   :URL "http://dx.doi.org/10.7287/peerj.1078v0.2/reviews/1",
+   :relation
+   {:is-review-of
+    [{:id-type "doi",
+      :id "10.7717/peerj.1078",
+      :asserted-by "subject"}]}}
+  {:institution
    {:name "Psychoceramics Institute",
     :place ["Pittsburg, Arizona"],
     :department ["Soft furnishings"],

--- a/dev-resources/works/?select=DOI.edn
+++ b/dev-resources/works/?select=DOI.edn
@@ -1,5 +1,5 @@
 {:facets {},
- :total-results 174,
+ :total-results 176,
  :items
  ({:DOI "10.1002/cphy.c160005"}
   {:DOI "10.1007/s11302-016-9551-2"}
@@ -8,7 +8,6 @@
   {:DOI "10.1016/j.neubiorev.2016.12.006"}
   {:DOI "10.1016/j.neubiorev.2016.12.013"}
   {:DOI "10.1016/j.neuroimage.2016.12.046"}
-  {:DOI "10.1016/j.psyneuen.2016.12.004"}
   {:DOI "10.1016/j.psyneuen.2016.12.006"}
   {:DOI "10.1016/j.psyneuen.2016.12.008"}
   {:DOI "10.1016/j.schres.2016.12.016"}
@@ -20,6 +19,7 @@
   {:DOI "10.1111/infa.12175"}
   {:DOI "10.3389/fendo.2016.00158"}
   {:DOI "10.3389/fendo.2016.00160"}
+  {:DOI "10.7287/peerj.1078v0.2/reviews/1"}
   {:DOI "10.7287/peerj.2196v0.1/reviews/2"}),
  :items-per-page 20,
  :query {:start-index 0, :search-terms nil}}

--- a/dev-resources/works/?select=member.edn
+++ b/dev-resources/works/?select=member.edn
@@ -1,7 +1,8 @@
 {:facets {},
- :total-results 174,
+ :total-results 176,
  :items
- ({:member "291"}
+ ({}
+  {:member "291"}
   {:member "1965"}
   {:member "341"}
   {:member "78"}
@@ -19,7 +20,6 @@
   {:member "316"}
   {:member "78"}
   {:member "297"}
-  {:member "78"}
   {:member "78"}),
  :items-per-page 20,
  :query {:start-index 0, :search-terms nil}}

--- a/dev-resources/works/?select=title.edn
+++ b/dev-resources/works/?select=title.edn
@@ -1,7 +1,9 @@
 {:facets {},
- :total-results 174,
+ :total-results 176,
  :items
  ({:title
+   ["Peer Review #1 of \"Multimodal Imaging Brain Connectivity Analysis (MIBCA) toolbox (v0.2)\""]}
+  {:title
    ["Peer Review #2 of \"Tissue mortality by Caribbean ciliate infection and white band disease in three reef-building coral species (v0.1)\""]}
   {:title
    ["Emerging Role of Corticosteroid-Binding Globulin in Glucocorticoid-Driven Metabolic Disorders"]}
@@ -37,8 +39,6 @@
   {:title
    ["Signaling pathways underlying the antidepressant-like effect of inosine in mice"]}
   {:title
-   ["The exercise-glucocorticoid paradox: How exercise is beneficial to cognition, mood, and the brain while increasing glucocorticoid levels"]}
-  {:title
-   ["Effects of the combination of metyrapone and oxazepam on cocaine-induced increases in corticosterone in the medial prefrontal cortex and nucleus accumbens"]}),
+   ["The exercise-glucocorticoid paradox: How exercise is beneficial to cognition, mood, and the brain while increasing glucocorticoid levels"]}),
  :items-per-page 20,
  :query {:start-index 0, :search-terms nil}}

--- a/dev-resources/works/?select=volume.edn
+++ b/dev-resources/works/?select=volume.edn
@@ -1,7 +1,8 @@
 {:facets {},
- :total-results 174,
+ :total-results 176,
  :items
  ({}
+  {}
   {:volume "7"}
   {:volume "114"}
   {:volume "44"}
@@ -19,7 +20,6 @@
   {:volume "8"}
   {:volume "73"}
   {:volume "13"}
-  {:volume "44"}
-  {:volume "77"}),
+  {:volume "44"}),
  :items-per-page 20,
  :query {:start-index 0, :search-terms nil}}

--- a/dev-resources/works/query.title=Peer.edn
+++ b/dev-resources/works/query.title=Peer.edn
@@ -1,7 +1,34 @@
 {:facets {},
- :total-results 1,
+ :total-results 2,
  :items
- ({:institution
+ ({:reference-count 0,
+   :content-domain {:domain []},
+   :published-print {:date-parts [[2015 7 14]]},
+   :DOI "10.7287/peerj.1078v0.2/reviews/1",
+   :type "peer-review",
+   :created
+   {:date-parts [[2018 1 10]],
+    :date-time "2018-01-10T17:22:19Z",
+    :timestamp 1515604939000},
+   :source "Crossref",
+   :is-referenced-by-count 0,
+   :title
+   ["Peer Review #1 of \"Multimodal Imaging Brain Connectivity Analysis (MIBCA) toolbox (v0.2)\""],
+   :prefix "10.7287",
+   :deposited
+   {:date-parts [[2018 1 10]],
+    :date-time "2018-01-10T17:22:19Z",
+    :timestamp 1515604939000},
+   :score 5.048995,
+   :issued {:date-parts [[2015 7 14]]},
+   :references-count 0,
+   :URL "http://dx.doi.org/10.7287/peerj.1078v0.2/reviews/1",
+   :relation
+   {:is-review-of
+    [{:id-type "doi",
+      :id "10.7717/peerj.1078",
+      :asserted-by "subject"}]}}
+  {:institution
    {:name "Psychoceramics Institute",
     :place ["Pittsburg, Arizona"],
     :department ["Soft furnishings"],
@@ -26,7 +53,7 @@
      :authenticated-orcid false,
      :given "Xiaoguang",
      :family "Fang",
-     :sequence "first"
+     :sequence "first",
      :affiliation []}],
    :member "291",
    :review
@@ -42,7 +69,7 @@
    {:date-parts [[2018 1 9]],
     :date-time "2018-01-09T18:42:21Z",
     :timestamp 1515523341000},
-   :score 4.377054,
+   :score 4.0195384,
    :subtitle ["The Subtitle"],
    :issued {:date-parts [[2017 4 19]]},
    :references-count 0,

--- a/dev-resources/works/query.title=Socioeconomic.edn
+++ b/dev-resources/works/query.title=Socioeconomic.edn
@@ -39,9 +39,18 @@
    :prefix "10.1016",
    :volume "75",
    :author
-   [{:given "Samuele", :family "Zilioli", :sequence "first" :affiliation []}
-    {:given "Ledina", :family "Imami", :sequence "additional" :affiliation []}
-    {:given "Richard B.", :family "Slatcher", :sequence "additional" :affiliation []}],
+   [{:given "Samuele",
+     :family "Zilioli",
+     :sequence "first",
+     :affiliation []}
+    {:given "Ledina",
+     :family "Imami",
+     :sequence "additional",
+     :affiliation []}
+    {:given "Richard B.",
+     :family "Slatcher",
+     :sequence "additional",
+     :affiliation []}],
    :member "78",
    :container-title ["Psychoneuroendocrinology"],
    :link
@@ -59,7 +68,7 @@
    {:date-parts [[2017 11 30]],
     :date-time "2017-11-30T15:51:07Z",
     :timestamp 1512057067000},
-   :score 5.5272517,
+   :score 5.5345345,
    :issued {:date-parts [[2017 1]]},
    :references-count 34,
    :alternative-id ["S0306453016307545"],

--- a/src/cayenne/formats/unixref.clj
+++ b/src/cayenne/formats/unixref.clj
@@ -10,7 +10,7 @@
             [taoensso.timbre :as timbre :refer [info error]]
             [cayenne.ids.ctn :refer [normalize-ctn]]
             [clojure.string :as string])
-  (:use [cayenne.util :only [?> ?>>]])
+  (:use [cayenne.util :only [?> ?>> safe-trim]])
   (:use [cayenne.ids.doi :only [to-long-doi-uri]])
   (:use [cayenne.ids.issn :only [to-issn-uri]])
   (:use [cayenne.ids.isbn :only [to-isbn-uri]])
@@ -861,13 +861,13 @@
         recommendation (xml/xselect1 peer-review-loc ["recommendation"])
         r-type (xml/xselect1 peer-review-loc ["type"])
         language (xml/xselect1 peer-review-loc ["language"])]
-    {:review {:running-number (string/trim running-number)
-              :revision-round (string/trim revision-round)
-              :stage (string/trim stage)
-              :competing-interest-statement (string/trim competing-interest-statement)
-              :recommendation (string/trim recommendation)
-              :review-type (string/trim r-type)
-              :language (string/trim language)}}))
+    {:review {:running-number (safe-trim running-number)
+              :revision-round (safe-trim revision-round)
+              :stage (safe-trim stage)
+              :competing-interest-statement (safe-trim competing-interest-statement)
+              :recommendation (safe-trim recommendation)
+              :review-type (safe-trim r-type)
+              :language (safe-trim language)}}))
 
 (defn parse-peer-review [peer-review-loc]
   (when peer-review-loc

--- a/src/cayenne/util.clj
+++ b/src/cayenne/util.clj
@@ -188,3 +188,6 @@
           (dissoc m k)))
       m)
     (dissoc m k)))
+
+(defn safe-trim [s]
+  (when s (string/trim s)))

--- a/test/cayenne/api_fixture.clj
+++ b/test/cayenne/api_fixture.clj
@@ -47,10 +47,10 @@
             feed-in-dir (str feed-dir "/feed-in")
             feed-processed-dir (str feed-dir "/feed-processed")
             feed-file-count (count (dir-seq-glob (path feed-source-dir) "*.body"))]
-        (when-not (= feed-file-count 174) 
+        (when-not (= feed-file-count 176) 
           (throw (Exception. 
                    (str "The number of feed input files is not as expected. Expected to find " 
-                        174 
+                        176 
                         " files in " 
                         feed-source-dir
                         " but found "

--- a/test/cayenne/works_test.clj
+++ b/test/cayenne/works_test.clj
@@ -6,10 +6,12 @@
 
 (deftest querying-works
   (testing "works endpoint returns expected result for DOI"
-    (doseq [doi ["10.1016/j.psyneuen.2016.10.018" "10.7287/peerj.2196v0.1/reviews/2"]]
+    (doseq [doi ["10.1016/j.psyneuen.2016.10.018" 
+                 "10.7287/peerj.2196v0.1/reviews/2" 
+                 "10.7287/peerj.1078v0.2/reviews/1"]]
       (let [response (api-get (str "/v1/works/" doi))
             expected-response (read-string (slurp (resource (str "works/" doi ".edn"))))]
-        (is (= expected-response response)))))
+        (is (= expected-response response) (str "Unexpected response for DOI " doi)))))
 
   (testing "works endpoint returns expected result for query"
     (doseq [q-filter ["query.title=Peer" "query.title=Socioeconomic"]]


### PR DESCRIPTION
This pull request protects against various parts of the review node not being present.

I've also added a new acceptance test and expected output for a more minimal scenario.

All of the functional change is in src/cayenne/formats/unixref.clj, the rest is acceptance test data additions and changes.