### PR TITLE
issue-36 funder route

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@
 /doc
 /tmp/*
 /log
+/dev-resources/feeds/feed-processed
+/.idea
 pom.xml
 .#*
 *.class

--- a/dev-resources/funders/100000002-works.edn
+++ b/dev-resources/funders/100000002-works.edn
@@ -1,0 +1,2131 @@
+{:facets {},
+ :total-results 23,
+ :items
+ ({:reference-count 64,
+   :publisher "Springer Nature",
+   :issue "3",
+   :license
+   [{:start
+     {:date-parts [[2016 11 11]],
+      :date-time "2016-11-11T00:00:00Z",
+      :timestamp 1478822400000},
+     :content-version "unspecified",
+     :delay-in-days 0,
+     :URL "http://www.springer.com/tdm"}],
+   :funder
+   [{:DOI "10.13039/100009633",
+     :name
+     "Eunice Kennedy Shriver National Institute of Child Health and Human Development",
+     :doi-asserted-by "publisher"}
+    {:name
+     "Division of Intramural Research, Eunice Kennedy Shriver National Institute of Child Health and Human Development"}
+    {:DOI "10.13039/100006686",
+     :name "University of Miami",
+     :doi-asserted-by "publisher"}],
+   :content-domain
+   {:domain ["link.springer.com"], :crossmark-restriction false},
+   :short-container-title ["Psychopharmacology"],
+   :published-print {:date-parts [[2017 2 1]]},
+   :DOI "10.1007/s00213-016-4480-x",
+   :type "journal-article",
+   :created
+   {:date-parts [[2016 11 11]],
+    :date-time "2016-11-11T10:35:51Z",
+    :timestamp 1478860551000},
+   :page "497-506",
+   :update-policy
+   "http://dx.doi.org/10.1007/springer_crossmark_policy",
+   :source "Crossref",
+   :is-referenced-by-count 9,
+   :title
+   ["Acute oxytocin improves memory and gaze following in male but not female nursery-reared infant macaques"],
+   :prefix "10.1007",
+   :volume "234",
+   :author
+   [{:given "Elizabeth A.",
+     :family "Simpson",
+     :sequence "first",
+     :affiliation []}
+    {:given "Annika",
+     :family "Paukner",
+     :sequence "additional",
+     :affiliation []}
+    {:given "Valentina",
+     :family "Sclafani",
+     :sequence "additional",
+     :affiliation []}
+    {:given "Stefano S. K.",
+     :family "Kaburu",
+     :sequence "additional",
+     :affiliation []}
+    {:given "Stephen J.",
+     :family "Suomi",
+     :sequence "additional",
+     :affiliation []}
+    {:given "Pier F.",
+     :family "Ferrari",
+     :sequence "additional",
+     :affiliation []}],
+   :member "297",
+   :published-online {:date-parts [[2016 11 11]]},
+   :container-title ["Psychopharmacology"],
+   :language "en",
+   :link
+   [{:URL
+     "http://link.springer.com/content/pdf/10.1007/s00213-016-4480-x.pdf",
+     :content-type "application/pdf",
+     :content-version "vor",
+     :intended-application "text-mining"}
+    {:URL
+     "http://link.springer.com/article/10.1007/s00213-016-4480-x/fulltext.html",
+     :content-type "text/html",
+     :content-version "vor",
+     :intended-application "text-mining"}
+    {:URL
+     "http://link.springer.com/content/pdf/10.1007/s00213-016-4480-x.pdf",
+     :content-type "application/pdf",
+     :content-version "vor",
+     :intended-application "similarity-checking"}],
+   :deposited
+   {:date-parts [[2017 6 25]],
+    :date-time "2017-06-25T03:22:48Z",
+    :timestamp 1498360968000},
+   :score 0.0,
+   :issued {:date-parts [[2016 11 11]]},
+   :references-count 64,
+   :journal-issue
+   {:issue "3", :published-print {:date-parts [[2017 2 1]]}},
+   :alternative-id ["4480"],
+   :URL "http://dx.doi.org/10.1007/s00213-016-4480-x",
+   :ISSN ["0033-3158" "1432-2072"],
+   :issn-type
+   [{:value "0033-3158", :type "print"}
+    {:value "1432-2072", :type "electronic"}]}
+  {:reference-count 70,
+   :publisher "Springer Nature",
+   :issue "1",
+   :license
+   [{:start
+     {:date-parts [[2016 10 25]],
+      :date-time "2016-10-25T00:00:00Z",
+      :timestamp 1477353600000},
+     :content-version "unspecified",
+     :delay-in-days 0,
+     :URL "http://www.springer.com/tdm"}],
+   :funder
+   [{:DOI "10.13039/100009633",
+     :name "National Institute of Mental Health",
+     :doi-asserted-by "publisher"}],
+   :content-domain
+   {:domain ["link.springer.com"], :crossmark-restriction false},
+   :short-container-title ["J Youth Adolescence"],
+   :published-print {:date-parts [[2017 1 1]]},
+   :DOI "10.1007/s10964-016-0591-2",
+   :type "journal-article",
+   :created
+   {:date-parts [[2016 10 25]],
+    :date-time "2016-10-25T05:40:53Z",
+    :timestamp 1477374053000},
+   :page "121-135",
+   :update-policy
+   "http://dx.doi.org/10.1007/springer_crossmark_policy",
+   :source "Crossref",
+   :is-referenced-by-count 3,
+   :title
+   ["Individual and Day-to-Day Differences in Active Coping Predict Diurnal Cortisol Patterns among Early Adolescent Girls"],
+   :prefix "10.1007",
+   :volume "46",
+   :author
+   [{:given "Michael R.",
+     :family "Sladek",
+     :sequence "first",
+     :affiliation []}
+    {:given "Leah D.",
+     :family "Doane",
+     :sequence "additional",
+     :affiliation []}
+    {:given "Catherine B.",
+     :family "Stroud",
+     :sequence "additional",
+     :affiliation []}],
+   :member "297",
+   :published-online {:date-parts [[2016 10 25]]},
+   :container-title ["Journal of Youth and Adolescence"],
+   :language "en",
+   :link
+   [{:URL
+     "http://link.springer.com/content/pdf/10.1007/s10964-016-0591-2.pdf",
+     :content-type "application/pdf",
+     :content-version "vor",
+     :intended-application "text-mining"}
+    {:URL
+     "http://link.springer.com/article/10.1007/s10964-016-0591-2/fulltext.html",
+     :content-type "text/html",
+     :content-version "vor",
+     :intended-application "text-mining"}
+    {:URL
+     "http://link.springer.com/content/pdf/10.1007/s10964-016-0591-2.pdf",
+     :content-type "application/pdf",
+     :content-version "vor",
+     :intended-application "similarity-checking"}],
+   :deposited
+   {:date-parts [[2017 6 25]],
+    :date-time "2017-06-25T02:00:55Z",
+    :timestamp 1498356055000},
+   :score 0.0,
+   :issued {:date-parts [[2016 10 25]]},
+   :references-count 70,
+   :journal-issue
+   {:issue "1", :published-print {:date-parts [[2017 1 1]]}},
+   :alternative-id ["591"],
+   :URL "http://dx.doi.org/10.1007/s10964-016-0591-2",
+   :ISSN ["0047-2891" "1573-6601"],
+   :issn-type
+   [{:value "0047-2891", :type "print"}
+    {:value "1573-6601", :type "electronic"}]}
+  {:reference-count 0,
+   :publisher "Elsevier BV",
+   :license
+   [{:start
+     {:date-parts [[2017 2 1]],
+      :date-time "2017-02-01T00:00:00Z",
+      :timestamp 1485907200000},
+     :content-version "tdm",
+     :delay-in-days 0,
+     :URL "http://www.elsevier.com/tdm/userlicense/1.0/"}],
+   :funder
+   [{:DOI "10.13039/100000002",
+     :name "National Institutes of Health",
+     :doi-asserted-by "publisher"}],
+   :content-domain
+   {:domain
+    ["clinicalkey.jp"
+     "alcoholjournal.org"
+     "clinicalkey.com"
+     "clinicalkey.es"
+     "clinicalkey.com.au"
+     "clinicalkey.fr"
+     "elsevier.com"
+     "sciencedirect.com"],
+    :crossmark-restriction true},
+   :short-container-title ["Alcohol"],
+   :published-print {:date-parts [[2017 2 1]]},
+   :DOI "10.1016/j.alcohol.2016.08.008",
+   :type "journal-article",
+   :created
+   {:date-parts [[2016 12 16]],
+    :date-time "2016-12-16T08:43:21Z",
+    :timestamp 1481877801000},
+   :page "139-151",
+   :update-policy "http://dx.doi.org/10.1016/elsevier_cm_policy",
+   :source "Crossref",
+   :is-referenced-by-count 2,
+   :title
+   ["Analyses of differentially expressed genes after exposure to acute stress, acute ethanol, or a combination of both in mice"],
+   :prefix "10.1016",
+   :volume "58",
+   :author
+   [{:given "Jessica A.",
+     :family "Baker",
+     :sequence "first",
+     :affiliation []}
+    {:given "Jingxin",
+     :family "Li",
+     :sequence "additional",
+     :affiliation []}
+    {:given "Diana",
+     :family "Zhou",
+     :sequence "additional",
+     :affiliation []}
+    {:given "Ming",
+     :family "Yang",
+     :sequence "additional",
+     :affiliation []}
+    {:given "Melloni N.",
+     :family "Cook",
+     :sequence "additional",
+     :affiliation []}
+    {:given "Byron C.",
+     :family "Jones",
+     :sequence "additional",
+     :affiliation []}
+    {:given "Megan K.",
+     :family "Mulligan",
+     :sequence "additional",
+     :affiliation []}
+    {:given "Kristin M.",
+     :family "Hamre",
+     :sequence "additional",
+     :affiliation []}
+    {:given "Lu",
+     :family "Lu",
+     :sequence "additional",
+     :affiliation []}],
+   :member "78",
+   :container-title ["Alcohol"],
+   :language "en",
+   :link
+   [{:URL
+     "http://api.elsevier.com/content/article/PII:S0741832916300714?httpAccept=text/plain",
+     :content-type "text/plain",
+     :content-version "vor",
+     :intended-application "text-mining"}
+    {:URL
+     "http://api.elsevier.com/content/article/PII:S0741832916300714?httpAccept=text/xml",
+     :content-type "text/xml",
+     :content-version "vor",
+     :intended-application "text-mining"}],
+   :deposited
+   {:date-parts [[2017 6 25]],
+    :date-time "2017-06-25T06:03:02Z",
+    :timestamp 1498370582000},
+   :score 0.0,
+   :issued {:date-parts [[2017 2 1]]},
+   :references-count 0,
+   :alternative-id ["S0741832916300714"],
+   :URL "http://dx.doi.org/10.1016/j.alcohol.2016.08.008",
+   :ISSN ["0741-8329"],
+   :issn-type [{:value "0741-8329", :type "print"}],
+   :assertion
+   [{:value "Elsevier",
+     :name "publisher",
+     :label "This article is maintained by"}
+    {:value
+     "Analyses of differentially expressed genes after exposure to acute stress, acute ethanol, or a combination of both in mice",
+     :name "articletitle",
+     :label "Article Title"}
+    {:value "Alcohol", :name "journaltitle", :label "Journal Title"}
+    {:value "http://dx.doi.org/10.1016/j.alcohol.2016.08.008",
+     :name "articlelink",
+     :label "CrossRef DOI link to publisher maintained version"}
+    {:value "article", :name "content_type", :label "Content Type"}
+    {:value "Published by Elsevier Inc.",
+     :name "copyright",
+     :label "Copyright"}]}
+  {:reference-count 0,
+   :publisher "Elsevier BV",
+   :issue "1",
+   :license
+   [{:start
+     {:date-parts [[2017 1 1]],
+      :date-time "2017-01-01T00:00:00Z",
+      :timestamp 1483228800000},
+     :content-version "tdm",
+     :delay-in-days 0,
+     :URL "http://www.elsevier.com/tdm/userlicense/1.0/"}],
+   :funder
+   [{:DOI "10.13039/100000002",
+     :name "NIH",
+     :doi-asserted-by "publisher"}
+    {:name "NIH OD"}],
+   :content-domain
+   {:domain ["elsevier.com" "sciencedirect.com"],
+    :crossmark-restriction true},
+   :short-container-title ["Bioorganic & Medicinal Chemistry"],
+   :published-print {:date-parts [[2017 1 1]]},
+   :DOI "10.1016/j.bmc.2016.10.035",
+   :type "journal-article",
+   :created
+   {:date-parts [[2016 11 1]],
+    :date-time "2016-11-01T08:31:03Z",
+    :timestamp 1477989063000},
+   :page "305-315",
+   :update-policy "http://dx.doi.org/10.1016/elsevier_cm_policy",
+   :source "Crossref",
+   :is-referenced-by-count 4,
+   :title
+   ["An evaluation of central penetration from a peripherally administered oxytocin receptor selective antagonist in nonhuman primates"],
+   :prefix "10.1016",
+   :volume "25",
+   :author
+   [{:given "Aaron L.",
+     :family "Smith",
+     :sequence "first",
+     :affiliation []}
+    {:given "Hasse",
+     :family "Walum",
+     :sequence "additional",
+     :affiliation []}
+    {:ORCID "http://orcid.org/0000-0003-3981-8654",
+     :authenticated-orcid false,
+     :given "Fawn",
+     :family "Connor-Stroud",
+     :sequence "additional",
+     :affiliation []}
+    {:given "Sara M.",
+     :family "Freeman",
+     :sequence "additional",
+     :affiliation []}
+    {:given "Kiyoshi",
+     :family "Inoue",
+     :sequence "additional",
+     :affiliation []}
+    {:given "Lisa A.",
+     :family "Parr",
+     :sequence "additional",
+     :affiliation []}
+    {:given "Mark M.",
+     :family "Goodman",
+     :sequence "additional",
+     :affiliation []}
+    {:given "Larry J.",
+     :family "Young",
+     :sequence "additional",
+     :affiliation []}],
+   :member "78",
+   :container-title ["Bioorganic & Medicinal Chemistry"],
+   :language "en",
+   :link
+   [{:URL
+     "http://api.elsevier.com/content/article/PII:S0968089616310872?httpAccept=text/plain",
+     :content-type "text/plain",
+     :content-version "vor",
+     :intended-application "text-mining"}
+    {:URL
+     "http://api.elsevier.com/content/article/PII:S0968089616310872?httpAccept=text/xml",
+     :content-type "text/xml",
+     :content-version "vor",
+     :intended-application "text-mining"}],
+   :deposited
+   {:date-parts [[2017 6 25]],
+    :date-time "2017-06-25T02:29:54Z",
+    :timestamp 1498357794000},
+   :score 0.0,
+   :issued {:date-parts [[2017 1 1]]},
+   :references-count 0,
+   :journal-issue
+   {:issue "1", :published-print {:date-parts [[2017 1 1]]}},
+   :alternative-id ["S0968089616310872"],
+   :URL "http://dx.doi.org/10.1016/j.bmc.2016.10.035",
+   :ISSN ["0968-0896"],
+   :issn-type [{:value "0968-0896", :type "print"}],
+   :assertion
+   [{:value "Elsevier",
+     :name "publisher",
+     :label "This article is maintained by"}
+    {:value
+     "An evaluation of central penetration from a peripherally administered oxytocin receptor selective antagonist in nonhuman primates",
+     :name "articletitle",
+     :label "Article Title"}
+    {:value "Bioorganic & Medicinal Chemistry",
+     :name "journaltitle",
+     :label "Journal Title"}
+    {:value "http://dx.doi.org/10.1016/j.bmc.2016.10.035",
+     :name "articlelink",
+     :label "CrossRef DOI link to publisher maintained version"}
+    {:value "article", :name "content_type", :label "Content Type"}
+    {:value "Published by Elsevier Ltd.",
+     :name "copyright",
+     :label "Copyright"}]}
+  {:reference-count 0,
+   :publisher "Elsevier BV",
+   :license
+   [{:start
+     {:date-parts [[2017 2 1]],
+      :date-time "2017-02-01T00:00:00Z",
+      :timestamp 1485907200000},
+     :content-version "tdm",
+     :delay-in-days 0,
+     :URL "http://www.elsevier.com/tdm/userlicense/1.0/"}],
+   :funder
+   [{:DOI "10.13039/100000025",
+     :name "National Institutes of Mental Health",
+     :doi-asserted-by "crossref"}
+    {:name
+     "Golden Family foundation, and Canadian Institutes of Health Research"}
+    {:name "Sir Henry Wellcome Postdoctoral Fellowship"}
+    {:name "Waterloo Foundation Child Development"}
+    {:DOI "10.13039/501100005366",
+     :name "University of Oslo",
+     :doi-asserted-by "crossref"}
+    {:name "NARSAD Young Investigator"}],
+   :content-domain
+   {:domain ["elsevier.com" "sciencedirect.com"],
+    :crossmark-restriction true},
+   :short-container-title ["Neuroscience & Biobehavioral Reviews"],
+   :published-print {:date-parts [[2017 2 1]]},
+   :DOI "10.1016/j.neubiorev.2016.12.013",
+   :type "journal-article",
+   :created
+   {:date-parts [[2016 12 16]],
+    :date-time "2016-12-16T23:37:30Z",
+    :timestamp 1481931450000},
+   :page "191-218",
+   :update-policy "http://dx.doi.org/10.1016/elsevier_cm_policy",
+   :source "Crossref",
+   :is-referenced-by-count 19,
+   :title
+   ["The neural diathesis-stress model of schizophrenia revisited: An update on recent findings considering illness stage and neurobiological and methodological complexities"],
+   :prefix "10.1016",
+   :volume "73",
+   :author
+   [{:given "Marita",
+     :family "Pruessner",
+     :sequence "first",
+     :affiliation []}
+    {:given "Alexis E.",
+     :family "Cullen",
+     :sequence "additional",
+     :affiliation []}
+    {:given "Monica",
+     :family "Aas",
+     :sequence "additional",
+     :affiliation []}
+    {:given "Elaine F.",
+     :family "Walker",
+     :sequence "additional",
+     :affiliation []}],
+   :member "78",
+   :container-title ["Neuroscience & Biobehavioral Reviews"],
+   :language "en",
+   :link
+   [{:URL
+     "http://api.elsevier.com/content/article/PII:S0149763416301713?httpAccept=text/plain",
+     :content-type "text/plain",
+     :content-version "vor",
+     :intended-application "text-mining"}
+    {:URL
+     "http://api.elsevier.com/content/article/PII:S0149763416301713?httpAccept=text/xml",
+     :content-type "text/xml",
+     :content-version "vor",
+     :intended-application "text-mining"}],
+   :deposited
+   {:date-parts [[2017 6 25]],
+    :date-time "2017-06-25T06:04:21Z",
+    :timestamp 1498370661000},
+   :score 0.0,
+   :issued {:date-parts [[2017 2 1]]},
+   :references-count 0,
+   :alternative-id ["S0149763416301713"],
+   :URL "http://dx.doi.org/10.1016/j.neubiorev.2016.12.013",
+   :ISSN ["0149-7634"],
+   :issn-type [{:value "0149-7634", :type "print"}],
+   :assertion
+   [{:value "Elsevier",
+     :name "publisher",
+     :label "This article is maintained by"}
+    {:value
+     "The neural diathesis-stress model of schizophrenia revisited: An update on recent findings considering illness stage and neurobiological and methodological complexities",
+     :name "articletitle",
+     :label "Article Title"}
+    {:value "Neuroscience & Biobehavioral Reviews",
+     :name "journaltitle",
+     :label "Journal Title"}
+    {:value "http://dx.doi.org/10.1016/j.neubiorev.2016.12.013",
+     :name "articlelink",
+     :label "CrossRef DOI link to publisher maintained version"}
+    {:value "article", :name "content_type", :label "Content Type"}
+    {:value "© 2016 Elsevier Ltd. All rights reserved.",
+     :name "copyright",
+     :label "Copyright"}]}
+  {:reference-count 0,
+   :publisher "Elsevier BV",
+   :license
+   [{:start
+     {:date-parts [[2017 5 1]],
+      :date-time "2017-05-01T00:00:00Z",
+      :timestamp 1493596800000},
+     :content-version "tdm",
+     :delay-in-days 0,
+     :URL "http://www.elsevier.com/tdm/userlicense/1.0/"}],
+   :funder
+   [{:DOI "10.13039/100000738",
+     :name "Department of Veterans Affairs",
+     :doi-asserted-by "crossref"}
+    {:DOI "10.13039/100000025",
+     :name "NIMH",
+     :doi-asserted-by "publisher"}
+    {:name "Yale Center for Clinical Investigation"}],
+   :content-domain
+   {:domain ["elsevier.com" "sciencedirect.com"],
+    :crossmark-restriction true},
+   :short-container-title ["Neuroscience Letters"],
+   :published-print {:date-parts [[2017 5 1]]},
+   :DOI "10.1016/j.neulet.2016.11.064",
+   :type "journal-article",
+   :created
+   {:date-parts [[2016 12 1]],
+    :date-time "2016-12-01T19:15:56Z",
+    :timestamp 1480619756000},
+   :page "147-155",
+   :update-policy "http://dx.doi.org/10.1016/elsevier_cm_policy",
+   :source "Crossref",
+   :is-referenced-by-count 10,
+   :title
+   ["Glutamate dysregulation and glutamatergic therapeutics for PTSD: Evidence from human studies"],
+   :prefix "10.1016",
+   :volume "649",
+   :author
+   [{:given "Lynnette A.",
+     :family "Averill",
+     :sequence "first",
+     :affiliation []}
+    {:given "Prerana",
+     :family "Purohit",
+     :sequence "additional",
+     :affiliation []}
+    {:given "Christopher L.",
+     :family "Averill",
+     :sequence "additional",
+     :affiliation []}
+    {:given "Markus A.",
+     :family "Boesl",
+     :sequence "additional",
+     :affiliation []}
+    {:given "John H.",
+     :family "Krystal",
+     :sequence "additional",
+     :affiliation []}
+    {:given "Chadi G.",
+     :family "Abdallah",
+     :sequence "additional",
+     :affiliation []}],
+   :member "78",
+   :container-title ["Neuroscience Letters"],
+   :language "en",
+   :link
+   [{:URL
+     "http://api.elsevier.com/content/article/PII:S0304394016309351?httpAccept=text/xml",
+     :content-type "text/xml",
+     :content-version "vor",
+     :intended-application "text-mining"}
+    {:URL
+     "http://api.elsevier.com/content/article/PII:S0304394016309351?httpAccept=text/plain",
+     :content-type "text/plain",
+     :content-version "vor",
+     :intended-application "text-mining"}],
+   :deposited
+   {:date-parts [[2017 12 19]],
+    :date-time "2017-12-19T01:21:02Z",
+    :timestamp 1513646462000},
+   :score 0.0,
+   :issued {:date-parts [[2017 5 1]]},
+   :references-count 0,
+   :alternative-id ["S0304394016309351"],
+   :URL "http://dx.doi.org/10.1016/j.neulet.2016.11.064",
+   :ISSN ["0304-3940"],
+   :issn-type [{:value "0304-3940", :type "print"}],
+   :assertion
+   [{:value "Elsevier",
+     :name "publisher",
+     :label "This article is maintained by"}
+    {:value
+     "Glutamate dysregulation and glutamatergic therapeutics for PTSD: Evidence from human studies",
+     :name "articletitle",
+     :label "Article Title"}
+    {:value "Neuroscience Letters",
+     :name "journaltitle",
+     :label "Journal Title"}
+    {:value "http://dx.doi.org/10.1016/j.neulet.2016.11.064",
+     :name "articlelink",
+     :label "CrossRef DOI link to publisher maintained version"}
+    {:value "article", :name "content_type", :label "Content Type"}
+    {:value "Published by Elsevier Ireland Ltd.",
+     :name "copyright",
+     :label "Copyright"}]}
+  {:reference-count 0,
+   :publisher "Elsevier BV",
+   :issue "1",
+   :license
+   [{:start
+     {:date-parts [[2016 10 1]],
+      :date-time "2016-10-01T00:00:00Z",
+      :timestamp 1475280000000},
+     :content-version "tdm",
+     :delay-in-days 0,
+     :URL "http://www.elsevier.com/tdm/userlicense/1.0/"}
+    {:start
+     {:date-parts [[2017 10 5]],
+      :date-time "2017-10-05T00:00:00Z",
+      :timestamp 1507161600000},
+     :content-version "vor",
+     :delay-in-days 369,
+     :URL "http://www.elsevier.com/open-access/userlicense/1.0/"}],
+   :funder
+   [{:DOI "10.13039/100000005",
+     :name "Department of Defense",
+     :doi-asserted-by "publisher"}
+    {:DOI "10.13039/100000025",
+     :name "National Institute of Mental Health",
+     :doi-asserted-by "publisher"}],
+   :content-domain
+   {:domain ["cell.com" "elsevier.com" "sciencedirect.com"],
+    :crossmark-restriction true},
+   :short-container-title ["Neuron"],
+   :published-print {:date-parts [[2016 10 1]]},
+   :DOI "10.1016/j.neuron.2016.09.039",
+   :type "journal-article",
+   :created
+   {:date-parts [[2016 10 5]],
+    :date-time "2016-10-05T17:06:26Z",
+    :timestamp 1475687186000},
+   :page "14-30",
+   :update-policy "http://dx.doi.org/10.1016/elsevier_cm_policy",
+   :source "Crossref",
+   :is-referenced-by-count 39,
+   :title
+   ["Context Processing and the Neurobiology of Post-Traumatic Stress Disorder"],
+   :prefix "10.1016",
+   :volume "92",
+   :author
+   [{:given "Israel",
+     :family "Liberzon",
+     :sequence "first",
+     :affiliation []}
+    {:given "James L.",
+     :family "Abelson",
+     :sequence "additional",
+     :affiliation []}],
+   :member "78",
+   :container-title ["Neuron"],
+   :language "en",
+   :link
+   [{:URL
+     "http://api.elsevier.com/content/article/PII:S0896627316306407?httpAccept=text/xml",
+     :content-type "text/xml",
+     :content-version "vor",
+     :intended-application "text-mining"}
+    {:URL
+     "http://api.elsevier.com/content/article/PII:S0896627316306407?httpAccept=text/plain",
+     :content-type "text/plain",
+     :content-version "vor",
+     :intended-application "text-mining"}],
+   :deposited
+   {:date-parts [[2017 10 28]],
+    :date-time "2017-10-28T20:46:11Z",
+    :timestamp 1509223571000},
+   :score 0.0,
+   :issued {:date-parts [[2016 10 1]]},
+   :references-count 0,
+   :journal-issue
+   {:issue "1", :published-print {:date-parts [[2016 10 1]]}},
+   :alternative-id ["S0896627316306407"],
+   :URL "http://dx.doi.org/10.1016/j.neuron.2016.09.039",
+   :ISSN ["0896-6273"],
+   :issn-type [{:value "0896-6273", :type "print"}],
+   :assertion
+   [{:value "Elsevier",
+     :name "publisher",
+     :label "This article is maintained by"}
+    {:value
+     "Context Processing and the Neurobiology of Post-Traumatic Stress Disorder",
+     :name "articletitle",
+     :label "Article Title"}
+    {:value "Neuron", :name "journaltitle", :label "Journal Title"}
+    {:value "http://dx.doi.org/10.1016/j.neuron.2016.09.039",
+     :name "articlelink",
+     :label "CrossRef DOI link to publisher maintained version"}
+    {:value "article", :name "content_type", :label "Content Type"}
+    {:value "Published by Elsevier Inc.",
+     :name "copyright",
+     :label "Copyright"}]}
+  {:reference-count 0,
+   :publisher "Elsevier BV",
+   :license
+   [{:start
+     {:date-parts [[2017 2 1]],
+      :date-time "2017-02-01T00:00:00Z",
+      :timestamp 1485907200000},
+     :content-version "tdm",
+     :delay-in-days 0,
+     :URL "http://www.elsevier.com/tdm/userlicense/1.0/"}],
+   :funder
+   [{:DOI "10.13039/100000002",
+     :name "NIH",
+     :doi-asserted-by "publisher"}
+    {:DOI "10.13039/100009429",
+     :name "NRSA",
+     :doi-asserted-by "crossref"}],
+   :content-domain
+   {:domain
+    ["psyneuen-journal.com"
+     "clinicalkey.jp"
+     "clinicalkey.com"
+     "clinicalkey.es"
+     "clinicalkey.com.au"
+     "clinicalkey.fr"
+     "elsevier.com"
+     "sciencedirect.com"],
+    :crossmark-restriction true},
+   :short-container-title ["Psychoneuroendocrinology"],
+   :published-print {:date-parts [[2017 2 1]]},
+   :DOI "10.1016/j.psyneuen.2016.10.023",
+   :type "journal-article",
+   :created
+   {:date-parts [[2016 11 19]],
+    :date-time "2016-11-19T17:02:15Z",
+    :timestamp 1479574935000},
+   :page "97-106",
+   :update-policy "http://dx.doi.org/10.1016/elsevier_cm_policy",
+   :source "Crossref",
+   :is-referenced-by-count 6,
+   :title
+   ["Motherhood and infant contact regulate neuroplasticity in the serotonergic midbrain dorsal raphe"],
+   :prefix "10.1016",
+   :volume "76",
+   :author
+   [{:given "M. Allie",
+     :family "Holschbach",
+     :sequence "first",
+     :affiliation []}
+    {:given "Joseph S.",
+     :family "Lonstein",
+     :sequence "additional",
+     :affiliation []}],
+   :member "78",
+   :container-title ["Psychoneuroendocrinology"],
+   :language "en",
+   :link
+   [{:URL
+     "http://api.elsevier.com/content/article/PII:S0306453016308605?httpAccept=text/plain",
+     :content-type "text/plain",
+     :content-version "vor",
+     :intended-application "text-mining"}
+    {:URL
+     "http://api.elsevier.com/content/article/PII:S0306453016308605?httpAccept=text/xml",
+     :content-type "text/xml",
+     :content-version "vor",
+     :intended-application "text-mining"}],
+   :deposited
+   {:date-parts [[2017 6 25]],
+    :date-time "2017-06-25T04:01:56Z",
+    :timestamp 1498363316000},
+   :score 0.0,
+   :issued {:date-parts [[2017 2 1]]},
+   :references-count 0,
+   :alternative-id ["S0306453016308605"],
+   :URL "http://dx.doi.org/10.1016/j.psyneuen.2016.10.023",
+   :ISSN ["0306-4530"],
+   :issn-type [{:value "0306-4530", :type "print"}],
+   :assertion
+   [{:value "Elsevier",
+     :name "publisher",
+     :label "This article is maintained by"}
+    {:value
+     "Motherhood and infant contact regulate neuroplasticity in the serotonergic midbrain dorsal raphe",
+     :name "articletitle",
+     :label "Article Title"}
+    {:value "Psychoneuroendocrinology",
+     :name "journaltitle",
+     :label "Journal Title"}
+    {:value "http://dx.doi.org/10.1016/j.psyneuen.2016.10.023",
+     :name "articlelink",
+     :label "CrossRef DOI link to publisher maintained version"}
+    {:value "article", :name "content_type", :label "Content Type"}
+    {:value "© 2016 Elsevier Ltd. All rights reserved.",
+     :name "copyright",
+     :label "Copyright"}]}
+  {:reference-count 0,
+   :publisher "Elsevier BV",
+   :license
+   [{:start
+     {:date-parts [[2017 1 1]],
+      :date-time "2017-01-01T00:00:00Z",
+      :timestamp 1483228800000},
+     :content-version "tdm",
+     :delay-in-days 0,
+     :URL "http://www.elsevier.com/tdm/userlicense/1.0/"}],
+   :funder
+   [{:DOI "10.13039/100000049",
+     :name "National Institute on Aging",
+     :doi-asserted-by "publisher"}
+    {:DOI "10.13039/100000071",
+     :name "National Institute of Child Health and Human Development",
+     :doi-asserted-by "publisher"}
+    {:DOI "10.13039/100000049",
+     :name "National Institute on Aging",
+     :doi-asserted-by "publisher"}
+    {:DOI "10.13039/100000026",
+     :name "National Institute on Drug Abuse",
+     :doi-asserted-by "publisher"}],
+   :content-domain
+   {:domain
+    ["psyneuen-journal.com"
+     "clinicalkey.jp"
+     "clinicalkey.com"
+     "clinicalkey.es"
+     "clinicalkey.com.au"
+     "clinicalkey.fr"
+     "elsevier.com"
+     "sciencedirect.com"],
+    :crossmark-restriction true},
+   :short-container-title ["Psychoneuroendocrinology"],
+   :published-print {:date-parts [[2017 1 1]]},
+   :DOI "10.1016/j.psyneuen.2016.10.026",
+   :type "journal-article",
+   :created
+   {:date-parts [[2016 10 29]],
+    :date-time "2016-10-29T15:01:26Z",
+    :timestamp 1477753286000},
+   :page "152-163",
+   :update-policy "http://dx.doi.org/10.1016/elsevier_cm_policy",
+   :source "Crossref",
+   :is-referenced-by-count 1,
+   :title
+   ["Frontal brain asymmetry, childhood maltreatment, and low-grade inflammation at midlife"],
+   :prefix "10.1016",
+   :volume "75",
+   :author
+   [{:given "Camelia E.",
+     :family "Hostinar",
+     :sequence "first",
+     :affiliation []}
+    {:given "Richard J.",
+     :family "Davidson",
+     :sequence "additional",
+     :affiliation []}
+    {:given "Eileen K.",
+     :family "Graham",
+     :sequence "additional",
+     :affiliation []}
+    {:given "Daniel K.",
+     :family "Mroczek",
+     :sequence "additional",
+     :affiliation []}
+    {:given "Margie E.",
+     :family "Lachman",
+     :sequence "additional",
+     :affiliation []}
+    {:given "Teresa E.",
+     :family "Seeman",
+     :sequence "additional",
+     :affiliation []}
+    {:given "Carien M.",
+     :family "van Reekum",
+     :sequence "additional",
+     :affiliation []}
+    {:given "Gregory E.",
+     :family "Miller",
+     :sequence "additional",
+     :affiliation []}],
+   :member "78",
+   :container-title ["Psychoneuroendocrinology"],
+   :language "en",
+   :link
+   [{:URL
+     "http://api.elsevier.com/content/article/PII:S0306453016308654?httpAccept=text/xml",
+     :content-type "text/xml",
+     :content-version "vor",
+     :intended-application "text-mining"}
+    {:URL
+     "http://api.elsevier.com/content/article/PII:S0306453016308654?httpAccept=text/plain",
+     :content-type "text/plain",
+     :content-version "vor",
+     :intended-application "text-mining"}],
+   :deposited
+   {:date-parts [[2017 11 30]],
+    :date-time "2017-11-30T15:51:40Z",
+    :timestamp 1512057100000},
+   :score 0.0,
+   :issued {:date-parts [[2017 1 1]]},
+   :references-count 0,
+   :alternative-id ["S0306453016308654"],
+   :URL "http://dx.doi.org/10.1016/j.psyneuen.2016.10.026",
+   :ISSN ["0306-4530"],
+   :issn-type [{:value "0306-4530", :type "print"}],
+   :assertion
+   [{:value "Elsevier",
+     :name "publisher",
+     :label "This article is maintained by"}
+    {:value
+     "Frontal brain asymmetry, childhood maltreatment, and low-grade inflammation at midlife",
+     :name "articletitle",
+     :label "Article Title"}
+    {:value "Psychoneuroendocrinology",
+     :name "journaltitle",
+     :label "Journal Title"}
+    {:value "http://dx.doi.org/10.1016/j.psyneuen.2016.10.026",
+     :name "articlelink",
+     :label "CrossRef DOI link to publisher maintained version"}
+    {:value "article", :name "content_type", :label "Content Type"}
+    {:value "© 2016 Elsevier Ltd. All rights reserved.",
+     :name "copyright",
+     :label "Copyright"}]}
+  {:reference-count 0,
+   :publisher "Elsevier BV",
+   :license
+   [{:start
+     {:date-parts [[2017 2 1]],
+      :date-time "2017-02-01T00:00:00Z",
+      :timestamp 1485907200000},
+     :content-version "tdm",
+     :delay-in-days 0,
+     :URL "http://www.elsevier.com/tdm/userlicense/1.0/"}
+    {:start
+     {:date-parts [[2017 11 23]],
+      :date-time "2017-11-23T00:00:00Z",
+      :timestamp 1511395200000},
+     :content-version "am",
+     :delay-in-days 295,
+     :URL "http://www.elsevier.com/open-access/userlicense/1.0/"}],
+   :funder
+   [{:DOI "10.13039/100000025",
+     :name "National Institute for Mental Health",
+     :doi-asserted-by "crossref"}
+    {:name "National Institute for Child Health and Development"}
+    {:name
+     "Integrated Training in Psychobiology and Psychopathology Fellowship"}
+    {:DOI "10.13039/100000001",
+     :name "National Science Foundation",
+     :doi-asserted-by "publisher"}
+    {:name
+     "National Institutes of Health, Office of Research Infrastructure Programs"}],
+   :content-domain
+   {:domain
+    ["psyneuen-journal.com"
+     "clinicalkey.jp"
+     "clinicalkey.com"
+     "clinicalkey.es"
+     "clinicalkey.com.au"
+     "clinicalkey.fr"
+     "elsevier.com"
+     "sciencedirect.com"],
+    :crossmark-restriction true},
+   :short-container-title ["Psychoneuroendocrinology"],
+   :published-print {:date-parts [[2017 2 1]]},
+   :DOI "10.1016/j.psyneuen.2016.11.018",
+   :type "journal-article",
+   :created
+   {:date-parts [[2016 11 18]],
+    :date-time "2016-11-18T20:17:20Z",
+    :timestamp 1479500240000},
+   :page "57-66",
+   :update-policy "http://dx.doi.org/10.1016/elsevier_cm_policy",
+   :source "Crossref",
+   :is-referenced-by-count 3,
+   :title
+   ["Increased anxiety-like behaviors, but blunted cortisol stress response after neonatal hippocampal lesions in monkeys"],
+   :prefix "10.1016",
+   :volume "76",
+   :author
+   [{:given "Jessica",
+     :family "Raper",
+     :sequence "first",
+     :affiliation []}
+    {:given "Mark",
+     :family "Wilson",
+     :sequence "additional",
+     :affiliation []}
+    {:given "Mar",
+     :family "Sanchez",
+     :sequence "additional",
+     :affiliation []}
+    {:given "Christa",
+     :family "Payne",
+     :sequence "additional",
+     :affiliation []}
+    {:given "Jocelyne",
+     :family "Bachevalier",
+     :sequence "additional",
+     :affiliation []}],
+   :member "78",
+   :container-title ["Psychoneuroendocrinology"],
+   :language "en",
+   :link
+   [{:URL
+     "http://api.elsevier.com/content/article/PII:S0306453016309210?httpAccept=text/xml",
+     :content-type "text/xml",
+     :content-version "vor",
+     :intended-application "text-mining"}
+    {:URL
+     "http://api.elsevier.com/content/article/PII:S0306453016309210?httpAccept=text/plain",
+     :content-type "text/plain",
+     :content-version "vor",
+     :intended-application "text-mining"}],
+   :deposited
+   {:date-parts [[2017 10 9]],
+    :date-time "2017-10-09T19:55:19Z",
+    :timestamp 1507578919000},
+   :score 0.0,
+   :issued {:date-parts [[2017 2 1]]},
+   :references-count 0,
+   :alternative-id ["S0306453016309210"],
+   :URL "http://dx.doi.org/10.1016/j.psyneuen.2016.11.018",
+   :ISSN ["0306-4530"],
+   :issn-type [{:value "0306-4530", :type "print"}],
+   :assertion
+   [{:value "Elsevier",
+     :name "publisher",
+     :label "This article is maintained by"}
+    {:value
+     "Increased anxiety-like behaviors, but blunted cortisol stress response after neonatal hippocampal lesions in monkeys",
+     :name "articletitle",
+     :label "Article Title"}
+    {:value "Psychoneuroendocrinology",
+     :name "journaltitle",
+     :label "Journal Title"}
+    {:value "http://dx.doi.org/10.1016/j.psyneuen.2016.11.018",
+     :name "articlelink",
+     :label "CrossRef DOI link to publisher maintained version"}
+    {:value "article", :name "content_type", :label "Content Type"}
+    {:value "© 2016 Elsevier Ltd. All rights reserved.",
+     :name "copyright",
+     :label "Copyright"}]}
+  {:reference-count 0,
+   :publisher "Elsevier BV",
+   :license
+   [{:start
+     {:date-parts [[2017 3 1]],
+      :date-time "2017-03-01T00:00:00Z",
+      :timestamp 1488326400000},
+     :content-version "tdm",
+     :delay-in-days 0,
+     :URL "http://www.elsevier.com/tdm/userlicense/1.0/"}],
+   :funder
+   [{:DOI "10.13039/100000002",
+     :name "National Institutes of Health",
+     :doi-asserted-by "publisher"}
+    {:name "State of Maryland"}
+    {:DOI "10.13039/100000874",
+     :name "Brain and Behavior Research Foundation",
+     :doi-asserted-by "publisher"}],
+   :content-domain
+   {:domain
+    ["psyneuen-journal.com"
+     "clinicalkey.jp"
+     "clinicalkey.com"
+     "clinicalkey.es"
+     "clinicalkey.com.au"
+     "clinicalkey.fr"
+     "elsevier.com"
+     "sciencedirect.com"],
+    :crossmark-restriction true},
+   :short-container-title ["Psychoneuroendocrinology"],
+   :published-print {:date-parts [[2017 3 1]]},
+   :DOI "10.1016/j.psyneuen.2016.11.021",
+   :type "journal-article",
+   :created
+   {:date-parts [[2016 11 24]],
+    :date-time "2016-11-24T23:32:18Z",
+    :timestamp 1480030338000},
+   :page "105-111",
+   :update-policy "http://dx.doi.org/10.1016/elsevier_cm_policy",
+   :source "Crossref",
+   :is-referenced-by-count 4,
+   :title
+   ["Allostatic load and reduced cortical thickness in schizophrenia"],
+   :prefix "10.1016",
+   :volume "77",
+   :author
+   [{:given "Joshua",
+     :family "Chiappelli",
+     :sequence "first",
+     :affiliation []}
+    {:given "Peter",
+     :family "Kochunov",
+     :sequence "additional",
+     :affiliation []}
+    {:given "Anya",
+     :family "Savransky",
+     :sequence "additional",
+     :affiliation []}
+    {:given "Feven",
+     :family "Fisseha",
+     :sequence "additional",
+     :affiliation []}
+    {:given "Krista",
+     :family "Wisner",
+     :sequence "additional",
+     :affiliation []}
+    {:given "Xiaoming",
+     :family "Du",
+     :sequence "additional",
+     :affiliation []}
+    {:given "Laura M.",
+     :family "Rowland",
+     :sequence "additional",
+     :affiliation []}
+    {:given "L. Elliot",
+     :family "Hong",
+     :sequence "additional",
+     :affiliation []}],
+   :member "78",
+   :container-title ["Psychoneuroendocrinology"],
+   :language "en",
+   :link
+   [{:URL
+     "http://api.elsevier.com/content/article/PII:S0306453016307600?httpAccept=text/xml",
+     :content-type "text/xml",
+     :content-version "vor",
+     :intended-application "text-mining"}
+    {:URL
+     "http://api.elsevier.com/content/article/PII:S0306453016307600?httpAccept=text/plain",
+     :content-type "text/plain",
+     :content-version "vor",
+     :intended-application "text-mining"}],
+   :deposited
+   {:date-parts [[2017 8 18]],
+    :date-time "2017-08-18T11:19:42Z",
+    :timestamp 1503055182000},
+   :score 0.0,
+   :issued {:date-parts [[2017 3 1]]},
+   :references-count 0,
+   :alternative-id ["S0306453016307600"],
+   :URL "http://dx.doi.org/10.1016/j.psyneuen.2016.11.021",
+   :ISSN ["0306-4530"],
+   :issn-type [{:value "0306-4530", :type "print"}],
+   :assertion
+   [{:value "Elsevier",
+     :name "publisher",
+     :label "This article is maintained by"}
+    {:value
+     "Allostatic load and reduced cortical thickness in schizophrenia",
+     :name "articletitle",
+     :label "Article Title"}
+    {:value "Psychoneuroendocrinology",
+     :name "journaltitle",
+     :label "Journal Title"}
+    {:value "http://dx.doi.org/10.1016/j.psyneuen.2016.11.021",
+     :name "articlelink",
+     :label "CrossRef DOI link to publisher maintained version"}
+    {:value "article", :name "content_type", :label "Content Type"}
+    {:value "© 2016 Elsevier Ltd. All rights reserved.",
+     :name "copyright",
+     :label "Copyright"}]}
+  {:reference-count 0,
+   :publisher "Elsevier BV",
+   :license
+   [{:start
+     {:date-parts [[2017 3 1]],
+      :date-time "2017-03-01T00:00:00Z",
+      :timestamp 1488326400000},
+     :content-version "tdm",
+     :delay-in-days 0,
+     :URL "http://www.elsevier.com/tdm/userlicense/1.0/"}],
+   :funder
+   [{:DOI "10.13039/100000002",
+     :name "NIH",
+     :doi-asserted-by "publisher"}],
+   :content-domain
+   {:domain
+    ["psyneuen-journal.com"
+     "clinicalkey.jp"
+     "clinicalkey.com"
+     "clinicalkey.es"
+     "clinicalkey.com.au"
+     "clinicalkey.fr"
+     "elsevier.com"
+     "sciencedirect.com"],
+    :crossmark-restriction true},
+   :short-container-title ["Psychoneuroendocrinology"],
+   :published-print {:date-parts [[2017 3 1]]},
+   :DOI "10.1016/j.psyneuen.2016.11.023",
+   :type "journal-article",
+   :created
+   {:date-parts [[2016 11 29]],
+    :date-time "2016-11-29T18:48:01Z",
+    :timestamp 1480445281000},
+   :page "51-55",
+   :update-policy "http://dx.doi.org/10.1016/elsevier_cm_policy",
+   :source "Crossref",
+   :is-referenced-by-count 1,
+   :title
+   ["Validation of autonomic and endocrine reactivity to a laboratory stressor in young children"],
+   :prefix "10.1016",
+   :volume "77",
+   :author
+   [{:given "Leslie E.",
+     :family "Roos",
+     :sequence "first",
+     :affiliation []}
+    {:given "Ryan J.",
+     :family "Giuliano",
+     :sequence "additional",
+     :affiliation []}
+    {:given "Kathryn G.",
+     :family "Beauchamp",
+     :sequence "additional",
+     :affiliation []}
+    {:given "Megan",
+     :family "Gunnar",
+     :sequence "additional",
+     :affiliation []}
+    {:given "Brigette",
+     :family "Amidon",
+     :sequence "additional",
+     :affiliation []}
+    {:given "Philip A.",
+     :family "Fisher",
+     :sequence "additional",
+     :affiliation []}],
+   :member "78",
+   :container-title ["Psychoneuroendocrinology"],
+   :language "en",
+   :link
+   [{:URL
+     "http://api.elsevier.com/content/article/PII:S0306453016306503?httpAccept=text/xml",
+     :content-type "text/xml",
+     :content-version "vor",
+     :intended-application "text-mining"}
+    {:URL
+     "http://api.elsevier.com/content/article/PII:S0306453016306503?httpAccept=text/plain",
+     :content-type "text/plain",
+     :content-version "vor",
+     :intended-application "text-mining"}],
+   :deposited
+   {:date-parts [[2017 8 18]],
+    :date-time "2017-08-18T11:20:22Z",
+    :timestamp 1503055222000},
+   :score 0.0,
+   :issued {:date-parts [[2017 3 1]]},
+   :references-count 0,
+   :alternative-id ["S0306453016306503"],
+   :URL "http://dx.doi.org/10.1016/j.psyneuen.2016.11.023",
+   :ISSN ["0306-4530"],
+   :issn-type [{:value "0306-4530", :type "print"}],
+   :assertion
+   [{:value "Elsevier",
+     :name "publisher",
+     :label "This article is maintained by"}
+    {:value
+     "Validation of autonomic and endocrine reactivity to a laboratory stressor in young children",
+     :name "articletitle",
+     :label "Article Title"}
+    {:value "Psychoneuroendocrinology",
+     :name "journaltitle",
+     :label "Journal Title"}
+    {:value "http://dx.doi.org/10.1016/j.psyneuen.2016.11.023",
+     :name "articlelink",
+     :label "CrossRef DOI link to publisher maintained version"}
+    {:value "article", :name "content_type", :label "Content Type"}
+    {:value "© 2016 Elsevier Ltd. All rights reserved.",
+     :name "copyright",
+     :label "Copyright"}]}
+  {:reference-count 0,
+   :publisher "Elsevier BV",
+   :license
+   [{:start
+     {:date-parts [[2017 3 1]],
+      :date-time "2017-03-01T00:00:00Z",
+      :timestamp 1488326400000},
+     :content-version "tdm",
+     :delay-in-days 0,
+     :URL "http://www.elsevier.com/tdm/userlicense/1.0/"}],
+   :funder
+   [{:DOI "10.13039/100000002",
+     :name "NIH",
+     :doi-asserted-by "publisher"}
+    {:DOI "10.13039/100000874",
+     :name "Brain & Behavior Research Foundation",
+     :doi-asserted-by "crossref"}],
+   :content-domain
+   {:domain
+    ["psyneuen-journal.com"
+     "clinicalkey.jp"
+     "clinicalkey.com"
+     "clinicalkey.es"
+     "clinicalkey.com.au"
+     "clinicalkey.fr"
+     "elsevier.com"
+     "sciencedirect.com"],
+    :crossmark-restriction true},
+   :short-container-title ["Psychoneuroendocrinology"],
+   :published-print {:date-parts [[2017 3 1]]},
+   :DOI "10.1016/j.psyneuen.2016.11.024",
+   :type "journal-article",
+   :created
+   {:date-parts [[2016 11 25]],
+    :date-time "2016-11-25T01:17:12Z",
+    :timestamp 1480036632000},
+   :page "68-74",
+   :update-policy "http://dx.doi.org/10.1016/elsevier_cm_policy",
+   :source "Crossref",
+   :is-referenced-by-count 2,
+   :title
+   ["The impact of the severity of early life stress on diurnal cortisol: The role of puberty"],
+   :prefix "10.1016",
+   :volume "77",
+   :author
+   [{:given "Lucy S.",
+     :family "King",
+     :sequence "first",
+     :affiliation []}
+    {:given "Natalie L.",
+     :family "Colich",
+     :sequence "additional",
+     :affiliation []}
+    {:given "Joelle",
+     :family "LeMoult",
+     :sequence "additional",
+     :affiliation []}
+    {:given "Kathryn L.",
+     :family "Humphreys",
+     :sequence "additional",
+     :affiliation []}
+    {:given "Sarah J.",
+     :family "Ordaz",
+     :sequence "additional",
+     :affiliation []}
+    {:given "Alexandria N.",
+     :family "Price",
+     :sequence "additional",
+     :affiliation []}
+    {:given "Ian H.",
+     :family "Gotlib",
+     :sequence "additional",
+     :affiliation []}],
+   :member "78",
+   :container-title ["Psychoneuroendocrinology"],
+   :language "en",
+   :link
+   [{:URL
+     "http://api.elsevier.com/content/article/PII:S030645301630498X?httpAccept=text/xml",
+     :content-type "text/xml",
+     :content-version "vor",
+     :intended-application "text-mining"}
+    {:URL
+     "http://api.elsevier.com/content/article/PII:S030645301630498X?httpAccept=text/plain",
+     :content-type "text/plain",
+     :content-version "vor",
+     :intended-application "text-mining"}],
+   :deposited
+   {:date-parts [[2017 8 18]],
+    :date-time "2017-08-18T11:19:36Z",
+    :timestamp 1503055176000},
+   :score 0.0,
+   :issued {:date-parts [[2017 3 1]]},
+   :references-count 0,
+   :alternative-id ["S030645301630498X"],
+   :URL "http://dx.doi.org/10.1016/j.psyneuen.2016.11.024",
+   :ISSN ["0306-4530"],
+   :issn-type [{:value "0306-4530", :type "print"}],
+   :assertion
+   [{:value "Elsevier",
+     :name "publisher",
+     :label "This article is maintained by"}
+    {:value
+     "The impact of the severity of early life stress on diurnal cortisol: The role of puberty",
+     :name "articletitle",
+     :label "Article Title"}
+    {:value "Psychoneuroendocrinology",
+     :name "journaltitle",
+     :label "Journal Title"}
+    {:value "http://dx.doi.org/10.1016/j.psyneuen.2016.11.024",
+     :name "articlelink",
+     :label "CrossRef DOI link to publisher maintained version"}
+    {:value "article", :name "content_type", :label "Content Type"}
+    {:value "© 2016 Elsevier Ltd. All rights reserved.",
+     :name "copyright",
+     :label "Copyright"}]}
+  {:reference-count 0,
+   :publisher "Elsevier BV",
+   :license
+   [{:start
+     {:date-parts [[2017 2 1]],
+      :date-time "2017-02-01T00:00:00Z",
+      :timestamp 1485907200000},
+     :content-version "tdm",
+     :delay-in-days 0,
+     :URL "http://www.elsevier.com/tdm/userlicense/1.0/"}],
+   :funder
+   [{:DOI "10.13039/100000025",
+     :name "National Institute of Mental Health",
+     :doi-asserted-by "publisher"}
+    {:name "O'Shaughnessy Foundation"}
+    {:name "Tinberg family, and grants from the UCSF Academic Senate"}
+    {:name "UCSF Research Evaluation and Allocation Committee"}
+    {:name
+     "National Institutes of Health/National Center for Research Resources"}
+    {:DOI "10.13039/100006108",
+     :name "National Center for Advancing Translational Sciences",
+     :doi-asserted-by "publisher"}],
+   :content-domain
+   {:domain
+    ["psyneuen-journal.com"
+     "clinicalkey.jp"
+     "clinicalkey.com"
+     "clinicalkey.es"
+     "clinicalkey.com.au"
+     "clinicalkey.fr"
+     "elsevier.com"
+     "sciencedirect.com"],
+    :crossmark-restriction true},
+   :short-container-title ["Psychoneuroendocrinology"],
+   :published-print {:date-parts [[2017 2 1]]},
+   :DOI "10.1016/j.psyneuen.2016.11.031",
+   :type "journal-article",
+   :created
+   {:date-parts [[2016 11 30]],
+    :date-time "2016-11-30T17:39:59Z",
+    :timestamp 1480527599000},
+   :page "197-205",
+   :update-policy "http://dx.doi.org/10.1016/elsevier_cm_policy",
+   :source "Crossref",
+   :is-referenced-by-count 22,
+   :title
+   ["Oxidative stress, inflammation and treatment response in major depression"],
+   :prefix "10.1016",
+   :volume "76",
+   :author
+   [{:given "Daniel",
+     :family "Lindqvist",
+     :sequence "first",
+     :affiliation []}
+    {:given "Firdaus S.",
+     :family "Dhabhar",
+     :sequence "additional",
+     :affiliation []}
+    {:given "S. Jill",
+     :family "James",
+     :sequence "additional",
+     :affiliation []}
+    {:given "Christina M.",
+     :family "Hough",
+     :sequence "additional",
+     :affiliation []}
+    {:given "Felipe A.",
+     :family "Jain",
+     :sequence "additional",
+     :affiliation []}
+    {:given "F. Saverio",
+     :family "Bersani",
+     :sequence "additional",
+     :affiliation []}
+    {:given "Victor I.",
+     :family "Reus",
+     :sequence "additional",
+     :affiliation []}
+    {:given "Josine E.",
+     :family "Verhoeven",
+     :sequence "additional",
+     :affiliation []}
+    {:given "Elissa S.",
+     :family "Epel",
+     :sequence "additional",
+     :affiliation []}
+    {:given "Laura",
+     :family "Mahan",
+     :sequence "additional",
+     :affiliation []}
+    {:given "Rebecca",
+     :family "Rosser",
+     :sequence "additional",
+     :affiliation []}
+    {:given "Owen M.",
+     :family "Wolkowitz",
+     :sequence "additional",
+     :affiliation []}
+    {:given "Synthia H.",
+     :family "Mellon",
+     :sequence "additional",
+     :affiliation []}],
+   :member "78",
+   :container-title ["Psychoneuroendocrinology"],
+   :language "en",
+   :link
+   [{:URL
+     "http://api.elsevier.com/content/article/PII:S0306453016306862?httpAccept=text/plain",
+     :content-type "text/plain",
+     :content-version "vor",
+     :intended-application "text-mining"}
+    {:URL
+     "http://api.elsevier.com/content/article/PII:S0306453016306862?httpAccept=text/xml",
+     :content-type "text/xml",
+     :content-version "vor",
+     :intended-application "text-mining"}],
+   :deposited
+   {:date-parts [[2017 6 25]],
+    :date-time "2017-06-25T04:53:05Z",
+    :timestamp 1498366385000},
+   :score 0.0,
+   :issued {:date-parts [[2017 2 1]]},
+   :references-count 0,
+   :alternative-id ["S0306453016306862"],
+   :URL "http://dx.doi.org/10.1016/j.psyneuen.2016.11.031",
+   :ISSN ["0306-4530"],
+   :issn-type [{:value "0306-4530", :type "print"}],
+   :assertion
+   [{:value "Elsevier",
+     :name "publisher",
+     :label "This article is maintained by"}
+    {:value
+     "Oxidative stress, inflammation and treatment response in major depression",
+     :name "articletitle",
+     :label "Article Title"}
+    {:value "Psychoneuroendocrinology",
+     :name "journaltitle",
+     :label "Journal Title"}
+    {:value "http://dx.doi.org/10.1016/j.psyneuen.2016.11.031",
+     :name "articlelink",
+     :label "CrossRef DOI link to publisher maintained version"}
+    {:value "article", :name "content_type", :label "Content Type"}
+    {:value "© 2016 Elsevier Ltd. All rights reserved.",
+     :name "copyright",
+     :label "Copyright"}]}
+  {:reference-count 0,
+   :publisher "Elsevier BV",
+   :license
+   [{:start
+     {:date-parts [[2017 3 1]],
+      :date-time "2017-03-01T00:00:00Z",
+      :timestamp 1488326400000},
+     :content-version "tdm",
+     :delay-in-days 0,
+     :URL "http://www.elsevier.com/tdm/userlicense/1.0/"}],
+   :funder
+   [{:DOI "10.13039/100000002",
+     :name "National Institutes of Health",
+     :doi-asserted-by "publisher"}],
+   :content-domain
+   {:domain
+    ["psyneuen-journal.com"
+     "clinicalkey.jp"
+     "clinicalkey.com"
+     "clinicalkey.es"
+     "clinicalkey.com.au"
+     "clinicalkey.fr"
+     "elsevier.com"
+     "sciencedirect.com"],
+    :crossmark-restriction true},
+   :short-container-title ["Psychoneuroendocrinology"],
+   :published-print {:date-parts [[2017 3 1]]},
+   :DOI "10.1016/j.psyneuen.2016.11.040",
+   :type "journal-article",
+   :created
+   {:date-parts [[2016 12 2]],
+    :date-time "2016-12-02T22:16:35Z",
+    :timestamp 1480716995000},
+   :page "37-46",
+   :update-policy "http://dx.doi.org/10.1016/elsevier_cm_policy",
+   :source "Crossref",
+   :is-referenced-by-count 5,
+   :title
+   ["Behavioral and physiological consequences of enrichment loss in rats"],
+   :prefix "10.1016",
+   :volume "77",
+   :author
+   [{:given "Brittany L.",
+     :family "Smith",
+     :sequence "first",
+     :affiliation []}
+    {:given "Carey E.",
+     :family "Lyons",
+     :sequence "additional",
+     :affiliation []}
+    {:given "Fernanda Guilhaume",
+     :family "Correa",
+     :sequence "additional",
+     :affiliation []}
+    {:given "Stephen C.",
+     :family "Benoit",
+     :sequence "additional",
+     :affiliation []}
+    {:given "Brent",
+     :family "Myers",
+     :sequence "additional",
+     :affiliation []}
+    {:given "Matia B.",
+     :family "Solomon",
+     :sequence "additional",
+     :affiliation []}
+    {:given "James P.",
+     :family "Herman",
+     :sequence "additional",
+     :affiliation []}],
+   :member "78",
+   :container-title ["Psychoneuroendocrinology"],
+   :language "en",
+   :link
+   [{:URL
+     "http://api.elsevier.com/content/article/PII:S0306453016304279?httpAccept=text/xml",
+     :content-type "text/xml",
+     :content-version "vor",
+     :intended-application "text-mining"}
+    {:URL
+     "http://api.elsevier.com/content/article/PII:S0306453016304279?httpAccept=text/plain",
+     :content-type "text/plain",
+     :content-version "vor",
+     :intended-application "text-mining"}],
+   :deposited
+   {:date-parts [[2017 8 18]],
+    :date-time "2017-08-18T11:19:14Z",
+    :timestamp 1503055154000},
+   :score 0.0,
+   :issued {:date-parts [[2017 3 1]]},
+   :references-count 0,
+   :alternative-id ["S0306453016304279"],
+   :URL "http://dx.doi.org/10.1016/j.psyneuen.2016.11.040",
+   :ISSN ["0306-4530"],
+   :issn-type [{:value "0306-4530", :type "print"}],
+   :assertion
+   [{:value "Elsevier",
+     :name "publisher",
+     :label "This article is maintained by"}
+    {:value
+     "Behavioral and physiological consequences of enrichment loss in rats",
+     :name "articletitle",
+     :label "Article Title"}
+    {:value "Psychoneuroendocrinology",
+     :name "journaltitle",
+     :label "Journal Title"}
+    {:value "http://dx.doi.org/10.1016/j.psyneuen.2016.11.040",
+     :name "articlelink",
+     :label "CrossRef DOI link to publisher maintained version"}
+    {:value "article", :name "content_type", :label "Content Type"}
+    {:value "© 2016 Elsevier Ltd. All rights reserved.",
+     :name "copyright",
+     :label "Copyright"}]}
+  {:reference-count 0,
+   :publisher "Elsevier BV",
+   :license
+   [{:start
+     {:date-parts [[2017 1 1]],
+      :date-time "2017-01-01T00:00:00Z",
+      :timestamp 1483228800000},
+     :content-version "tdm",
+     :delay-in-days 0,
+     :URL "http://www.elsevier.com/tdm/userlicense/1.0/"}],
+   :funder
+   [{:DOI "10.13039/100000025",
+     :name "National Institute of Mental Health",
+     :doi-asserted-by "crossref"}
+    {:name "Eunice Kennedy Shriver National Institute of Child Health"}
+    {:name "Human Development of the National Institutes of Health"}],
+   :content-domain
+   {:domain
+    ["clinicalkey.jp"
+     "clinicalkey.com"
+     "clinicalkey.es"
+     "clinicalkey.com.au"
+     "clinicalkey.fr"
+     "elsevier.com"
+     "sciencedirect.com"],
+    :crossmark-restriction true},
+   :short-container-title ["Frontiers in Neuroendocrinology"],
+   :published-print {:date-parts [[2017 1 1]]},
+   :DOI "10.1016/j.yfrne.2016.12.003",
+   :type "journal-article",
+   :created
+   {:date-parts [[2016 12 19]],
+    :date-time "2016-12-19T21:31:26Z",
+    :timestamp 1482183086000},
+   :page "122-137",
+   :update-policy "http://dx.doi.org/10.1016/elsevier_cm_policy",
+   :source "Crossref",
+   :is-referenced-by-count 12,
+   :title ["Puberty and structural brain development in humans"],
+   :prefix "10.1016",
+   :volume "44",
+   :author
+   [{:given "Megan M.",
+     :family "Herting",
+     :sequence "first",
+     :affiliation []}
+    {:given "Elizabeth R.",
+     :family "Sowell",
+     :sequence "additional",
+     :affiliation []}],
+   :member "78",
+   :container-title ["Frontiers in Neuroendocrinology"],
+   :language "en",
+   :link
+   [{:URL
+     "http://api.elsevier.com/content/article/PII:S0091302216300632?httpAccept=text/xml",
+     :content-type "text/xml",
+     :content-version "vor",
+     :intended-application "text-mining"}
+    {:URL
+     "http://api.elsevier.com/content/article/PII:S0091302216300632?httpAccept=text/plain",
+     :content-type "text/plain",
+     :content-version "vor",
+     :intended-application "text-mining"}],
+   :deposited
+   {:date-parts [[2017 6 10]],
+    :date-time "2017-06-10T02:01:10Z",
+    :timestamp 1497060070000},
+   :score 0.0,
+   :issued {:date-parts [[2017 1 1]]},
+   :references-count 0,
+   :alternative-id ["S0091302216300632"],
+   :URL "http://dx.doi.org/10.1016/j.yfrne.2016.12.003",
+   :ISSN ["0091-3022"],
+   :issn-type [{:value "0091-3022", :type "print"}],
+   :assertion
+   [{:value "Elsevier",
+     :name "publisher",
+     :label "This article is maintained by"}
+    {:value "Puberty and structural brain development in humans",
+     :name "articletitle",
+     :label "Article Title"}
+    {:value "Frontiers in Neuroendocrinology",
+     :name "journaltitle",
+     :label "Journal Title"}
+    {:value "http://dx.doi.org/10.1016/j.yfrne.2016.12.003",
+     :name "articlelink",
+     :label "CrossRef DOI link to publisher maintained version"}
+    {:value "article", :name "content_type", :label "Content Type"}
+    {:value "© 2017 Elsevier Inc. All rights reserved.",
+     :name "copyright",
+     :label "Copyright"}]}
+  {:reference-count 0,
+   :publisher "American Chemical Society (ACS)",
+   :issue "2",
+   :funder
+   [{:DOI "10.13039/100000027",
+     :name "National Institute on Alcohol Abuse and Alcoholism",
+     :doi-asserted-by "publisher"}
+    {:DOI "10.13039/100000026",
+     :name "National Institute on Drug Abuse",
+     :doi-asserted-by "publisher"}],
+   :content-domain {:domain [], :crossmark-restriction false},
+   :short-container-title ["ACS Chem. Neurosci."],
+   :published-print {:date-parts [[2017 2 15]]},
+   :DOI "10.1021/acschemneuro.6b00308",
+   :type "journal-article",
+   :created
+   {:date-parts [[2016 12 14]],
+    :date-time "2016-12-14T15:42:38Z",
+    :timestamp 1481730158000},
+   :page "290-299",
+   :source "Crossref",
+   :is-referenced-by-count 3,
+   :title
+   ["High-Fat-Diet-Induced Deficits in Dopamine Terminal Function Are Reversed by Restoring Insulin Signaling"],
+   :prefix "10.1021",
+   :volume "8",
+   :author
+   [{:ORCID "http://orcid.org/0000-0002-7093-6774",
+     :authenticated-orcid false,
+     :given "Steve C.",
+     :family "Fordahl",
+     :sequence "first",
+     :affiliation
+     [{:name
+       "Department of Physiology\rand Pharmacology, Wake Forest School of Medicine, Winston-Salem, North Carolina 27157, United States"}]}
+    {:given "Sara R.",
+     :family "Jones",
+     :sequence "additional",
+     :affiliation
+     [{:name
+       "Department of Physiology\rand Pharmacology, Wake Forest School of Medicine, Winston-Salem, North Carolina 27157, United States"}]}],
+   :member "316",
+   :published-online {:date-parts [[2017 1 3]]},
+   :container-title ["ACS Chemical Neuroscience"],
+   :language "en",
+   :link
+   [{:URL "http://pubs.acs.org/doi/pdf/10.1021/acschemneuro.6b00308",
+     :content-type "unspecified",
+     :content-version "vor",
+     :intended-application "similarity-checking"}],
+   :deposited
+   {:date-parts [[2018 1 3]],
+    :date-time "2018-01-03T12:44:56Z",
+    :timestamp 1514983496000},
+   :score 0.0,
+   :issued {:date-parts [[2017 1 3]]},
+   :references-count 0,
+   :journal-issue
+   {:issue "2",
+    :published-online {:date-parts [[2016 12 19]]},
+    :published-print {:date-parts [[2017 2 15]]}},
+   :alternative-id ["10.1021/acschemneuro.6b00308"],
+   :URL "http://dx.doi.org/10.1021/acschemneuro.6b00308",
+   :ISSN ["1948-7193" "1948-7193"],
+   :issn-type
+   [{:value "1948-7193", :type "print"}
+    {:value "1948-7193", :type "electronic"}]}
+  {:reference-count 54,
+   :publisher
+   "American Association for the Advancement of Science (AAAS)",
+   :issue "6315",
+   :license
+   [{:start
+     {:date-parts [[2017 11 25]],
+      :date-time "2017-11-25T00:00:00Z",
+      :timestamp 1511568000000},
+     :content-version "vor",
+     :delay-in-days 366,
+     :URL
+     "http://www.sciencemag.org/about/science-licenses-journal-article-reuse"}],
+   :funder
+   [{:DOI "10.13039/100000002",
+     :name "NIH",
+     :doi-asserted-by "publisher"}
+    {:DOI "10.13039/100000001",
+     :name "NSF",
+     :doi-asserted-by "publisher"}
+    {:DOI "10.13039/501100001804",
+     :name "Canada Research Chairs Program",
+     :doi-asserted-by "publisher"}
+    {:DOI "10.13039/501100000038",
+     :name "NSERC",
+     :doi-asserted-by "publisher"}
+    {:DOI "10.13039/100008240",
+     :name "Fonds de recherche du Quebec",
+     :doi-asserted-by "publisher"}],
+   :content-domain {:domain [], :crossmark-restriction false},
+   :short-container-title ["Science"],
+   :published-print {:date-parts [[2016 11 25]]},
+   :DOI "10.1126/science.aah3580",
+   :type "journal-article",
+   :created
+   {:date-parts [[2016 11 24]],
+    :date-time "2016-11-24T18:45:13Z",
+    :timestamp 1480013113000},
+   :page "1041-1045",
+   :source "Crossref",
+   :is-referenced-by-count 27,
+   :title
+   ["Social status alters immune regulation and response to infection in macaques"],
+   :prefix "10.1126",
+   :volume "354",
+   :author
+   [{:given "Noah",
+     :family "Snyder-Mackler",
+     :sequence "first",
+     :affiliation []}
+    {:given "Joaquín",
+     :family "Sanz",
+     :sequence "additional",
+     :affiliation []}
+    {:given "Jordan N.",
+     :family "Kohn",
+     :sequence "additional",
+     :affiliation []}
+    {:given "Jessica F.",
+     :family "Brinkworth",
+     :sequence "additional",
+     :affiliation []}
+    {:given "Shauna",
+     :family "Morrow",
+     :sequence "additional",
+     :affiliation []}
+    {:given "Amanda O.",
+     :family "Shaver",
+     :sequence "additional",
+     :affiliation []}
+    {:given "Jean-Christophe",
+     :family "Grenier",
+     :sequence "additional",
+     :affiliation []}
+    {:given "Roger",
+     :family "Pique-Regi",
+     :sequence "additional",
+     :affiliation []}
+    {:given "Zachary P.",
+     :family "Johnson",
+     :sequence "additional",
+     :affiliation []}
+    {:given "Mark E.",
+     :family "Wilson",
+     :sequence "additional",
+     :affiliation []}
+    {:given "Luis B.",
+     :family "Barreiro",
+     :sequence "additional",
+     :affiliation []}
+    {:given "Jenny",
+     :family "Tung",
+     :sequence "additional",
+     :affiliation []}],
+   :member "221",
+   :published-online {:date-parts [[2016 11 24]]},
+   :container-title ["Science"],
+   :language "en",
+   :link
+   [{:URL
+     "https://syndication.highwire.org/content/doi/10.1126/science.aah3580",
+     :content-type "unspecified",
+     :content-version "vor",
+     :intended-application "similarity-checking"}],
+   :deposited
+   {:date-parts [[2017 5 8]],
+    :date-time "2017-05-08T15:03:02Z",
+    :timestamp 1494255782000},
+   :score 0.0,
+   :issued {:date-parts [[2016 11 24]]},
+   :references-count 54,
+   :journal-issue
+   {:issue "6315",
+    :published-online {:date-parts [[2016 11 24]]},
+    :published-print {:date-parts [[2016 11 25]]}},
+   :alternative-id ["10.1126/science.aah3580"],
+   :URL "http://dx.doi.org/10.1126/science.aah3580",
+   :ISSN ["0036-8075" "1095-9203"],
+   :issn-type
+   [{:value "0036-8075", :type "print"}
+    {:value "1095-9203", :type "electronic"}]}
+  {:reference-count 63,
+   :publisher "Springer Nature",
+   :issue "1",
+   :funder
+   [{:DOI "10.13039/100000025",
+     :name "National Institute of Mental Health",
+     :doi-asserted-by "publisher"}
+    {:name "Johns Hopkins Military and Veterans Health Institute"}
+    {:DOI "10.13039/100000066",
+     :name "National Institute of Environmental Health Sciences",
+     :doi-asserted-by "publisher"}],
+   :content-domain
+   {:domain ["link.springer.com"], :crossmark-restriction false},
+   :short-container-title ["Clin Epigenet"],
+   :published-print {:date-parts [[2016 12 1]]},
+   :DOI "10.1186/s13148-016-0279-1",
+   :type "journal-article",
+   :created
+   {:date-parts [[2016 11 3]],
+    :date-time "2016-11-03T10:30:22Z",
+    :timestamp 1478169022000},
+   :update-policy
+   "http://dx.doi.org/10.1007/springer_crossmark_policy",
+   :source "Crossref",
+   :is-referenced-by-count 5,
+   :title
+   ["Discovery and replication of a peripheral tissue DNA methylation biosignature to augment a suicide prediction model"],
+   :prefix "10.1186",
+   :volume "8",
+   :author
+   [{:given "Makena L.",
+     :family "Clive",
+     :sequence "first",
+     :affiliation []}
+    {:given "Marco P.",
+     :family "Boks",
+     :sequence "additional",
+     :affiliation []}
+    {:given "Christiaan H.",
+     :family "Vinkers",
+     :sequence "additional",
+     :affiliation []}
+    {:given "Lauren M.",
+     :family "Osborne",
+     :sequence "additional",
+     :affiliation []}
+    {:given "Jennifer L.",
+     :family "Payne",
+     :sequence "additional",
+     :affiliation []}
+    {:given "Kerry J.",
+     :family "Ressler",
+     :sequence "additional",
+     :affiliation []}
+    {:given "Alicia K.",
+     :family "Smith",
+     :sequence "additional",
+     :affiliation []}
+    {:given "Holly C.",
+     :family "Wilcox",
+     :sequence "additional",
+     :affiliation []}
+    {:given "Zachary",
+     :family "Kaminsky",
+     :sequence "additional",
+     :affiliation []}],
+   :member "297",
+   :published-online {:date-parts [[2016 11 3]]},
+   :container-title ["Clinical Epigenetics"],
+   :language "en",
+   :link
+   [{:URL
+     "http://link.springer.com/content/pdf/10.1186/s13148-016-0279-1.pdf",
+     :content-type "application/pdf",
+     :content-version "vor",
+     :intended-application "similarity-checking"}],
+   :deposited
+   {:date-parts [[2017 6 25]],
+    :date-time "2017-06-25T02:42:28Z",
+    :timestamp 1498358548000},
+   :score 0.0,
+   :issued {:date-parts [[2016 11 3]]},
+   :references-count 63,
+   :journal-issue
+   {:issue "1", :published-print {:date-parts [[2016 12 1]]}},
+   :alternative-id ["279"],
+   :URL "http://dx.doi.org/10.1186/s13148-016-0279-1",
+   :ISSN ["1868-7075" "1868-7083"],
+   :issn-type
+   [{:value "1868-7075", :type "print"}
+    {:value "1868-7083", :type "electronic"}]}
+  {:reference-count 84,
+   :publisher "Frontiers Media SA",
+   :funder
+   [{:DOI "10.13039/100000002",
+     :name "National Institutes of Health",
+     :doi-asserted-by "publisher"}],
+   :content-domain
+   {:domain ["frontiersin.org"], :crossmark-restriction true},
+   :short-container-title ["Front. Behav. Neurosci."],
+   :published-print {:date-parts [[2016 11 14]]},
+   :DOI "10.3389/fnbeh.2016.00221",
+   :type "journal-article",
+   :created
+   {:date-parts [[2016 11 14]],
+    :date-time "2016-11-14T03:08:14Z",
+    :timestamp 1479092894000},
+   :update-policy "http://dx.doi.org/10.3389/crossmark-policy",
+   :source "Crossref",
+   :is-referenced-by-count 9,
+   :title
+   ["Challenges to the Pair Bond: Neural and Hormonal Effects of Separation and Reunion in a Monogamous Primate"],
+   :prefix "10.3389",
+   :volume "10",
+   :author
+   [{:given "Katie",
+     :family "Hinde",
+     :sequence "first",
+     :affiliation []}
+    {:given "Chelsea",
+     :family "Muth",
+     :sequence "additional",
+     :affiliation []}
+    {:given "Nicole",
+     :family "Maninger",
+     :sequence "additional",
+     :affiliation []}
+    {:given "Benjamin J.",
+     :family "Ragen",
+     :sequence "additional",
+     :affiliation []}
+    {:given "Rebecca H.",
+     :family "Larke",
+     :sequence "additional",
+     :affiliation []}
+    {:given "Michael R.",
+     :family "Jarcho",
+     :sequence "additional",
+     :affiliation []}
+    {:given "Sally P.",
+     :family "Mendoza",
+     :sequence "additional",
+     :affiliation []}
+    {:given "William A.",
+     :family "Mason",
+     :sequence "additional",
+     :affiliation []}
+    {:given "Emilio",
+     :family "Ferrer",
+     :sequence "additional",
+     :affiliation []}
+    {:given "Simon R.",
+     :family "Cherry",
+     :sequence "additional",
+     :affiliation []}
+    {:given "Marina L.",
+     :family "Fisher-Phelps",
+     :sequence "additional",
+     :affiliation []}
+    {:given "Karen L.",
+     :family "Bales",
+     :sequence "additional",
+     :affiliation []}],
+   :member "1965",
+   :published-online {:date-parts [[2016 11 14]]},
+   :container-title ["Frontiers in Behavioral Neuroscience"],
+   :link
+   [{:URL
+     "http://journal.frontiersin.org/article/10.3389/fnbeh.2016.00221/full",
+     :content-type "unspecified",
+     :content-version "vor",
+     :intended-application "similarity-checking"}],
+   :deposited
+   {:date-parts [[2017 6 25]],
+    :date-time "2017-06-25T03:29:44Z",
+    :timestamp 1498361384000},
+   :score 0.0,
+   :issued {:date-parts [[2016 11 14]]},
+   :references-count 84,
+   :URL "http://dx.doi.org/10.3389/fnbeh.2016.00221",
+   :ISSN ["1662-5153"],
+   :issn-type [{:value "1662-5153", :type "electronic"}]}),
+ :items-per-page 20,
+ :query {:start-index 0, :search-terms nil}}

--- a/dev-resources/funders/100009429-works.edn
+++ b/dev-resources/funders/100009429-works.edn
@@ -1,0 +1,101 @@
+{:facets {},
+ :total-results 1,
+ :items
+ ({:reference-count 0,
+   :publisher "Elsevier BV",
+   :license
+   [{:start
+     {:date-parts [[2017 2 1]],
+      :date-time "2017-02-01T00:00:00Z",
+      :timestamp 1485907200000},
+     :content-version "tdm",
+     :delay-in-days 0,
+     :URL "http://www.elsevier.com/tdm/userlicense/1.0/"}],
+   :funder
+   [{:DOI "10.13039/100000002",
+     :name "NIH",
+     :doi-asserted-by "publisher"}
+    {:DOI "10.13039/100009429",
+     :name "NRSA",
+     :doi-asserted-by "crossref"}],
+   :content-domain
+   {:domain
+    ["psyneuen-journal.com"
+     "clinicalkey.jp"
+     "clinicalkey.com"
+     "clinicalkey.es"
+     "clinicalkey.com.au"
+     "clinicalkey.fr"
+     "elsevier.com"
+     "sciencedirect.com"],
+    :crossmark-restriction true},
+   :short-container-title ["Psychoneuroendocrinology"],
+   :published-print {:date-parts [[2017 2 1]]},
+   :DOI "10.1016/j.psyneuen.2016.10.023",
+   :type "journal-article",
+   :created
+   {:date-parts [[2016 11 19]],
+    :date-time "2016-11-19T17:02:15Z",
+    :timestamp 1479574935000},
+   :page "97-106",
+   :update-policy "http://dx.doi.org/10.1016/elsevier_cm_policy",
+   :source "Crossref",
+   :is-referenced-by-count 6,
+   :title
+   ["Motherhood and infant contact regulate neuroplasticity in the serotonergic midbrain dorsal raphe"],
+   :prefix "10.1016",
+   :volume "76",
+   :author
+   [{:given "M. Allie",
+     :family "Holschbach",
+     :sequence "first",
+     :affiliation []}
+    {:given "Joseph S.",
+     :family "Lonstein",
+     :sequence "additional",
+     :affiliation []}],
+   :member "78",
+   :container-title ["Psychoneuroendocrinology"],
+   :language "en",
+   :link
+   [{:URL
+     "http://api.elsevier.com/content/article/PII:S0306453016308605?httpAccept=text/plain",
+     :content-type "text/plain",
+     :content-version "vor",
+     :intended-application "text-mining"}
+    {:URL
+     "http://api.elsevier.com/content/article/PII:S0306453016308605?httpAccept=text/xml",
+     :content-type "text/xml",
+     :content-version "vor",
+     :intended-application "text-mining"}],
+   :deposited
+   {:date-parts [[2017 6 25]],
+    :date-time "2017-06-25T04:01:56Z",
+    :timestamp 1498363316000},
+   :score 0.0,
+   :issued {:date-parts [[2017 2 1]]},
+   :references-count 0,
+   :alternative-id ["S0306453016308605"],
+   :URL "http://dx.doi.org/10.1016/j.psyneuen.2016.10.023",
+   :ISSN ["0306-4530"],
+   :issn-type [{:value "0306-4530", :type "print"}],
+   :assertion
+   [{:value "Elsevier",
+     :name "publisher",
+     :label "This article is maintained by"}
+    {:value
+     "Motherhood and infant contact regulate neuroplasticity in the serotonergic midbrain dorsal raphe",
+     :name "articletitle",
+     :label "Article Title"}
+    {:value "Psychoneuroendocrinology",
+     :name "journaltitle",
+     :label "Journal Title"}
+    {:value "http://dx.doi.org/10.1016/j.psyneuen.2016.10.023",
+     :name "articlelink",
+     :label "CrossRef DOI link to publisher maintained version"}
+    {:value "article", :name "content_type", :label "Content Type"}
+    {:value "© 2016 Elsevier Ltd. All rights reserved.",
+     :name "copyright",
+     :label "Copyright"}]}),
+ :items-per-page 20,
+ :query {:start-index 0, :search-terms nil}}

--- a/dev-resources/funders/501100001602-works.edn
+++ b/dev-resources/funders/501100001602-works.edn
@@ -1,0 +1,227 @@
+{:facets {},
+ :total-results 2,
+ :items
+ ({:reference-count 0,
+   :publisher "Elsevier BV",
+   :license
+   [{:start
+     {:date-parts [[2017 2 1]],
+      :date-time "2017-02-01T00:00:00Z",
+      :timestamp 1485907200000},
+     :content-version "tdm",
+     :delay-in-days 0,
+     :URL "http://www.elsevier.com/tdm/userlicense/1.0/"}],
+   :funder
+   [{:name
+     "Health Research Board, Ireland (HRB) through Health Research Awards"}
+    {:DOI "10.13039/501100001602",
+     :name "Science Foundation Ireland",
+     :doi-asserted-by "publisher"}],
+   :content-domain
+   {:domain ["elsevier.com" "sciencedirect.com"],
+    :crossmark-restriction true},
+   :short-container-title ["Neuroscience & Biobehavioral Reviews"],
+   :published-print {:date-parts [[2017 2 1]]},
+   :DOI "10.1016/j.neubiorev.2016.12.006",
+   :type "journal-article",
+   :created
+   {:date-parts [[2016 12 13]],
+    :date-time "2016-12-13T23:18:23Z",
+    :timestamp 1481671103000},
+   :page "123-164",
+   :update-policy "http://dx.doi.org/10.1016/elsevier_cm_policy",
+   :source "Crossref",
+   :is-referenced-by-count 14,
+   :title
+   ["A systematic review of the psychobiological burden of informal caregiving for patients with dementia: Focus on cognitive and biological markers of chronic stress"],
+   :prefix "10.1016",
+   :volume "73",
+   :author
+   [{:given "Andrew P.",
+     :family "Allen",
+     :sequence "first",
+     :affiliation []}
+    {:given "Eileen A.",
+     :family "Curran",
+     :sequence "additional",
+     :affiliation []}
+    {:given "Áine",
+     :family "Duggan",
+     :sequence "additional",
+     :affiliation []}
+    {:given "John F.",
+     :family "Cryan",
+     :sequence "additional",
+     :affiliation []}
+    {:given "Aoife Ní",
+     :family "Chorcoráin",
+     :sequence "additional",
+     :affiliation []}
+    {:given "Timothy G.",
+     :family "Dinan",
+     :sequence "additional",
+     :affiliation []}
+    {:given "D. William",
+     :family "Molloy",
+     :sequence "additional",
+     :affiliation []}
+    {:given "Patricia M.",
+     :family "Kearney",
+     :sequence "additional",
+     :affiliation []}
+    {:given "Gerard",
+     :family "Clarke",
+     :sequence "additional",
+     :affiliation []}],
+   :member "78",
+   :container-title ["Neuroscience & Biobehavioral Reviews"],
+   :language "en",
+   :link
+   [{:URL
+     "http://api.elsevier.com/content/article/PII:S0149763416302792?httpAccept=text/plain",
+     :content-type "text/plain",
+     :content-version "vor",
+     :intended-application "text-mining"}
+    {:URL
+     "http://api.elsevier.com/content/article/PII:S0149763416302792?httpAccept=text/xml",
+     :content-type "text/xml",
+     :content-version "vor",
+     :intended-application "text-mining"}],
+   :deposited
+   {:date-parts [[2017 6 25]],
+    :date-time "2017-06-25T05:51:22Z",
+    :timestamp 1498369882000},
+   :score 0.0,
+   :issued {:date-parts [[2017 2 1]]},
+   :references-count 0,
+   :alternative-id ["S0149763416302792"],
+   :URL "http://dx.doi.org/10.1016/j.neubiorev.2016.12.006",
+   :ISSN ["0149-7634"],
+   :issn-type [{:value "0149-7634", :type "print"}],
+   :assertion
+   [{:value "Elsevier",
+     :name "publisher",
+     :label "This article is maintained by"}
+    {:value
+     "A systematic review of the psychobiological burden of informal caregiving for patients with dementia: Focus on cognitive and biological markers of chronic stress",
+     :name "articletitle",
+     :label "Article Title"}
+    {:value "Neuroscience & Biobehavioral Reviews",
+     :name "journaltitle",
+     :label "Journal Title"}
+    {:value "http://dx.doi.org/10.1016/j.neubiorev.2016.12.006",
+     :name "articlelink",
+     :label "CrossRef DOI link to publisher maintained version"}
+    {:value "article", :name "content_type", :label "Content Type"}
+    {:value "© 2016 Elsevier Ltd. All rights reserved.",
+     :name "copyright",
+     :label "Copyright"}]}
+  {:reference-count 0,
+   :publisher "Elsevier BV",
+   :license
+   [{:start
+     {:date-parts [[2017 2 1]],
+      :date-time "2017-02-01T00:00:00Z",
+      :timestamp 1485907200000},
+     :content-version "tdm",
+     :delay-in-days 0,
+     :URL "http://www.elsevier.com/tdm/userlicense/1.0/"}
+    {:start
+     {:date-parts [[2016 7 1]],
+      :date-time "2016-07-01T00:00:00Z",
+      :timestamp 1467331200000},
+     :content-version "vor",
+     :delay-in-days 0,
+     :URL "http://creativecommons.org/licenses/by-nc-nd/4.0/"}],
+   :funder
+   [{:name "Health Research Board, Ireland (HRB)"}
+    {:DOI "10.13039/501100001602",
+     :name "Science Foundation Ireland",
+     :doi-asserted-by "publisher"}],
+   :content-domain
+   {:domain ["elsevier.com" "sciencedirect.com"],
+    :crossmark-restriction true},
+   :short-container-title ["Neurobiology of Stress"],
+   :published-print {:date-parts [[2017 2 1]]},
+   :DOI "10.1016/j.ynstr.2016.11.001",
+   :type "journal-article",
+   :created
+   {:date-parts [[2016 11 12]],
+    :date-time "2016-11-12T07:31:05Z",
+    :timestamp 1478935865000},
+   :page "113-126",
+   :update-policy "http://dx.doi.org/10.1016/elsevier_cm_policy",
+   :source "Crossref",
+   :is-referenced-by-count 9,
+   :title ["The Trier Social Stress Test: Principles and practice"],
+   :prefix "10.1016",
+   :volume "6",
+   :author
+   [{:given "Andrew P.",
+     :family "Allen",
+     :sequence "first",
+     :affiliation []}
+    {:given "Paul J.",
+     :family "Kennedy",
+     :sequence "additional",
+     :affiliation []}
+    {:given "Samantha",
+     :family "Dockray",
+     :sequence "additional",
+     :affiliation []}
+    {:given "John F.",
+     :family "Cryan",
+     :sequence "additional",
+     :affiliation []}
+    {:given "Timothy G.",
+     :family "Dinan",
+     :sequence "additional",
+     :affiliation []}
+    {:given "Gerard",
+     :family "Clarke",
+     :sequence "additional",
+     :affiliation []}],
+   :member "78",
+   :container-title ["Neurobiology of Stress"],
+   :language "en",
+   :link
+   [{:URL
+     "http://api.elsevier.com/content/article/PII:S2352289516300224?httpAccept=text/xml",
+     :content-type "text/xml",
+     :content-version "vor",
+     :intended-application "text-mining"}
+    {:URL
+     "http://api.elsevier.com/content/article/PII:S2352289516300224?httpAccept=text/plain",
+     :content-type "text/plain",
+     :content-version "vor",
+     :intended-application "text-mining"}],
+   :deposited
+   {:date-parts [[2017 7 13]],
+    :date-time "2017-07-13T16:58:45Z",
+    :timestamp 1499965125000},
+   :score 0.0,
+   :issued {:date-parts [[2017 2 1]]},
+   :references-count 0,
+   :alternative-id ["S2352289516300224"],
+   :URL "http://dx.doi.org/10.1016/j.ynstr.2016.11.001",
+   :ISSN ["2352-2895"],
+   :issn-type [{:value "2352-2895", :type "print"}],
+   :assertion
+   [{:value "Elsevier",
+     :name "publisher",
+     :label "This article is maintained by"}
+    {:value "The Trier Social Stress Test: Principles and practice",
+     :name "articletitle",
+     :label "Article Title"}
+    {:value "Neurobiology of Stress",
+     :name "journaltitle",
+     :label "Journal Title"}
+    {:value "http://dx.doi.org/10.1016/j.ynstr.2016.11.001",
+     :name "articlelink",
+     :label "CrossRef DOI link to publisher maintained version"}
+    {:value "article", :name "content_type", :label "Content Type"}
+    {:value "© 2016 The Authors. Published by Elsevier Inc.",
+     :name "copyright",
+     :label "Copyright"}]}),
+ :items-per-page 20,
+ :query {:start-index 0, :search-terms nil}}

--- a/src/cayenne/api/v1/filter.clj
+++ b/src/cayenne/api/v1/filter.clj
@@ -95,11 +95,10 @@
 ;; todo :transformers
 (defn nested-terms [prefix suffixes & {:keys [transformers]}]
   (fn [val]
-    (println val)
     (let [field-name (->> val first (str (name prefix) ".") keyword)]
       {:occurrence :filter
        :clause
-       {:nested {:path prefix :query {:term {field-name (-> val second first)}}}}})))
+       {:nested {:path prefix :query {:terms {field-name  (second val) }}}}})))
 
   ;; (letfn [(field-name [field]
   ;;           (keyword (str (name prefix)

--- a/src/cayenne/api/v1/filter.clj
+++ b/src/cayenne/api/v1/filter.clj
@@ -182,12 +182,12 @@
    "funder-doi-asserted-by"    (-> (equality :funder.doi-asserted-by) (nested :funder))
    "has-assertion"             (-> (existence :assertion) (nested :assertion))
    "has-clinical-trial-number" (-> (existence :clinical-trial) (nested :clinical-trial))
-   "full-text"                 (nested-terms :link {:type :content-type
+   "full-text"                 (nested-terms :link {:type        :content-type
                                                     :application :application
-                                                    :version :version})
-   "license"                   (nested-terms :license {:url :url
+                                                    :version     :version})
+   "license"                   (nested-terms :license {:url     :url
                                                        :version :version
-                                                       :delay :delay}
+                                                       :delay   :delay}
                                              :matchers {:delay #(str ":[* TO " % "]")})
    "archive"                   (equality :archive)
    "article-number"            (equality :article-number)
@@ -209,24 +209,26 @@
    "award"                     (nested-terms :funder {:funder-doi :doi
                                                       :funder     :doi
                                                       :number     :award}
-                                       :transformers
-                                       {:funder-doi doi-id/with-funder-prefix
-                                        :funder doi-id/with-funder-prefix
-                                        :number #(-> %
-                                                     string/lower-case
-                                                     string/replace #"[\s_\-]+" "")})
-   "relation"                  (nested-terms :relation {:type :type
+                                             :transformers
+                                             {:funder-doi doi-id/with-funder-prefix
+                                              :funder     doi-id/with-funder-prefix
+                                              :number     #(-> %
+                                                               string/lower-case
+                                                               string/replace #"[\s_\-]+" "")})
+   "relation"                  (nested-terms :relation {:type        :type
                                                         :object-type :object-type
-                                                        :object-ns :object-ns
-                                                        :claimed-by :claimed-by
-                                                        :object :object})
+                                                        :object-ns   :object-ns
+                                                        :claimed-by  :claimed-by
+                                                        :object      :object})
    "member"                    (equality :member-id
                                          :transformer member-id/extract-member-id)
    "journal"                   (equality :journal-id)
    "prefix"                    (equality :owner-prefix
                                          :transformer prefix/extract-prefix)
-   "funder"                    (equality :funder-doi
-                                         :transformer doi-id/with-funder-prefix)})
+   "funder"                    (nested-terms :funder {:funder-doi :doi}
+                                             :transformers
+                                             {:funder-doi doi-id/with-funder-prefix})
+   })
                               
 (def member-filters
   {"prefix"                (equality :prefix.value)

--- a/src/cayenne/api/v1/filter.clj
+++ b/src/cayenne/api/v1/filter.clj
@@ -99,6 +99,8 @@
       {:occurrence :filter
        :clause
        {:nested {:path prefix :query {:terms {field-name  (second val) }}}}})))
+      ; nested terms could be called with a list of values,
+      ; the es-fetch handles them, so don't take only the first item
 
   ;; (letfn [(field-name [field]
   ;;           (keyword (str (name prefix)

--- a/src/cayenne/api/v1/query.clj
+++ b/src/cayenne/api/v1/query.clj
@@ -259,7 +259,7 @@
 
     ;; todo could be rewritten to use /type/type/id
     id-field
-          (assoc-in [:query :bool :should] [(conj {:term {id-field (:id query-context)}})])
+    (update-in [:query :bool :should] conj {:term {id-field (:id query-context)}})
 
     ;; todo only considering first filter value
     (-> query-context :filters empty? not)

--- a/src/cayenne/api/v1/query.clj
+++ b/src/cayenne/api/v1/query.clj
@@ -259,7 +259,7 @@
 
     ;; todo could be rewritten to use /type/type/id
     id-field
-    (update-in [:query :bool :should] conj {:term {id-field (:id query-context)}})
+          (assoc-in [:query :bool :should] [(conj {:term {id-field (:id query-context)}})])
 
     ;; todo only considering first filter value
     (-> query-context :filters empty? not)

--- a/src/cayenne/api/v1/routes.clj
+++ b/src/cayenne/api/v1/routes.clj
@@ -225,7 +225,6 @@
   :allowed-methods [:get :options :head]
   :available-media-types t/json
   :handle-ok #(funder/fetch-works (->> funder-id
-                                       doi-id/with-funder-prefix
                                        (q/->query-context % :id))))
 
 (defresource prefix-resource [px]

--- a/src/cayenne/data/funder.clj
+++ b/src/cayenne/data/funder.clj
@@ -21,7 +21,7 @@
       (get-in [:body :_source :descendant])))
 
 (defn fetch-descendant-work-count [funder-doi]
-  (let [funder-dois (conj (fetch-descendant-dois funder-doi)
+  (let [funder-dois (conj (fetch-descendant-dois (doi-id/doi-uri-to-id funder-doi))
                           funder-doi)
         nested-query {:bool
                       {:should
@@ -102,8 +102,10 @@
 ;; todo currently won't work due to filter.clj compounds only accepting
 ;;      one value per filter name 
 (defn fetch-works [query-context]
-  (let [funder-doi (:id query-context)
-        filter-dois (conj (fetch-descendant-dois funder-doi) funder-doi)]
+  (let [funder-doi  (doi-id/doi-uri-to-id (:id query-context))
+
+        filter-dois (conj (fetch-descendant-dois funder-doi) funder-doi)
+        filter-dois-with-prefix (map doi-id/with-funder-prefix filter-dois)]
     (work/fetch
      (-> query-context
-         (assoc :filter {"funder" {"doi" filter-dois}})))))
+         (assoc :filters {"funder" {"doi" filter-dois-with-prefix}})))))

--- a/src/cayenne/ids/doi.clj
+++ b/src/cayenne/ids/doi.clj
@@ -60,7 +60,8 @@
       (if (string/blank? normalized-doi)
         nil
         (ids/get-id-uri :long-doi normalized-doi)))))
- 
+
+; todo: put funder id functions in their own namespace again?
 (defn to-short-doi-uri 
   "Ensure a short DOI is in a normalized URI form."
   [s]
@@ -68,12 +69,14 @@
     (ids/get-id-uri :short-doi (normalize-short-doi s))))
 
 (defn doi-uri-to-id
+  "takes the last portion of a doi after the last /. Useful for funder identifiers"
   [doi]
   (last (string/split doi #"/")))
 
 (defn with-prefix [doi prefix]
+  "used to convert a funder id to a funder doi"
   (->> doi
-       doi-uri-to-id
+       doi-uri-to-id ;in case we're passed a funder doi instead of just the ID
        (str prefix "/")))
 
 (defn with-funder-prefix [doi]

--- a/src/cayenne/ids/doi.clj
+++ b/src/cayenne/ids/doi.clj
@@ -67,9 +67,13 @@
   (when s
     (ids/get-id-uri :short-doi (normalize-short-doi s))))
 
+(defn doi-uri-to-id
+  [doi]
+  (last (string/split doi #"/")))
+
 (defn with-prefix [doi prefix]
   (->> doi
-       extract-long-suffix
+       doi-uri-to-id
        (str prefix "/")))
 
 (defn with-funder-prefix [doi]

--- a/test/cayenne/funders_test.clj
+++ b/test/cayenne/funders_test.clj
@@ -19,11 +19,17 @@
     (doseq [funder ["100000001" "100006151" "501100000315" "501100000314"]]
       (let [response (api-get (str "/v1/funders/" funder))
             expected-response (read-string (slurp (resource (str "funders/" funder ".edn"))))]
-        (is (= expected-response response))))))
+        (is (= expected-response response)))))
+  (testing "funders/works endpoint returns expected result for funder"
+  (doseq [funder ["100000002" "100009429" "501100001602" ]]
+    (let [response (api-get (str "/v1/funders/" funder "/works"))
+          expected-response (read-string (slurp (resource (str "funders/" funder "-works.edn"))))]
+      (is (= expected-response response))))))
 
 (use-fixtures
   :once
   (api-with
     #(do (user/load-test-funders)
+         (user/index-feed)
          ;; todo wait until indexing finished
          (Thread/sleep 5000))))


### PR DESCRIPTION
The funder indexing was failing due to a self reference in the ingest RDF
file. Once that was fixed, testing revealed that the funder route for works was broken e.g.:
/funders/100006151/works
The fix here is for the funder works route.