### PR TITLE
Issue 419 more logging

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject crossref/cayenne "1.2.2"
+(defproject crossref/cayenne "1.2.3"
   :description "Index and serve CrossRef metadata"
   :url "http://github.com/CrossRef/cayenne"
   :signing {:gpg-key "labs@crossref.org"}

--- a/src/cayenne/api/v1/feed.clj
+++ b/src/cayenne/api/v1/feed.clj
@@ -109,9 +109,10 @@
     (.renameTo from-file to-file)))
 
 (defn make-feed-context
-  ([content-type provider]
+  ([content-type provider doi]
    (let [base {:content-type content-type
                :provider provider
+               :doi doi
                :id (new-id)}]
      (-> base
          (assoc :incoming-file (incoming-file base))
@@ -137,7 +138,7 @@
   
 (defmulti process! :content-type)
 
-(defmethod process! "application/vnd.datacite.datacite+xml" [feed-context]
+(defmethod process! "application/vnd.datacite.datacite+xml" [feed-context filename]
   (process-with
    (fn [rdr]
      (let [f #(let [parsed (->> %
@@ -150,7 +151,7 @@
        (xml/process-xml rdr "record" f)))
    feed-context))
 
-(defmethod process! "application/vnd.crossref.unixsd+xml" [feed-context]
+(defmethod process! "application/vnd.crossref.unixsd+xml" [feed-context filename]
   (process-with
    (fn [rdr]
      (let [f #(let [parsed (->> %
@@ -161,12 +162,14 @@
                                 (apply itree/centre-on))
                     with-source (assoc parsed
                                        :source
-                                       (-> feed-context :provider provider-names))]
+                                       (-> feed-context :provider provider-names))
+                    doi (first (get-item-ids parsed :long-doi))]
+                (feed-log (filename) (str "parsed file for DOI:" doi))
                    (solr/insert-item with-source))]
        (xml/process-xml rdr "crossref_result" f)))
    feed-context))
 
-(defmethod process! "application/vnd.crossref.update+json" [feed-context]
+(defmethod process! "application/vnd.crossref.update+json" [feed-context filename]
   (process-with
    #(doseq [update-doc (->> %
                             read-updates-message
@@ -177,7 +180,7 @@
 (defn process-feed-file! [f]
   (try
     (feed-log (.getName f) "Preparing to process")
-    (-> f .getAbsolutePath make-feed-context process!)
+    (-> f .getAbsolutePath make-feed-context (process! (.getName f)))
     (feed-log (.getName f) "Processed")
     (catch Exception e
       (feed-log (.getName f) "Failed")
@@ -189,7 +192,7 @@
     (.mkdirs (.getParentFile incoming-file))
     (io/copy body incoming-file)
     (meter/mark! files-received)
-    (feed-log (.getName incoming-file) "Received and stored")
+    (feed-log (.getName incoming-file) (str "Received and stored for doi:" (:doi feed-context)))
     (assoc feed-context :digest (digest/md5 incoming-file))))
 
 (defn strip-content-type-params [ct]
@@ -210,7 +213,7 @@
   :post! #(let [result (-> %
                            (get-in [:request :headers "content-type"])
                            strip-content-type-params
-                           (make-feed-context provider)
+                           (make-feed-context provider  (get-in % [:request :headers "doi"]))
                            (record! (get-in % [:request :body])))]
             (assoc % :digest (:digest result)))
   :handle-created #(r/api-response :feed-file-creation :content {:digest (:digest %)}))

--- a/src/cayenne/api/v1/feed.clj
+++ b/src/cayenne/api/v1/feed.clj
@@ -133,6 +133,8 @@
         (move-file! (:incoming-file feed-context)
                     (:processed-file feed-context)))
       (catch Exception e
+        (feed-log (:incoming-file feed-context) (str "Exception while processing file: " (.getMessage e)))
+        (error e (str "Failed to process feed file " (:incoming-file feed-context)))
         (move-file! (:incoming-file feed-context)
                     (:failed-file feed-context))))))
   
@@ -164,7 +166,7 @@
                                        :source
                                        (-> feed-context :provider provider-names))
                     doi (first (itree/get-item-ids parsed :long-doi))]
-                (feed-log (filename) (str "parsed file for DOI:" doi))
+                   (feed-log (filename) (str "parsed file for DOI:" doi))
                    (solr/insert-item with-source))]
        (xml/process-xml rdr "crossref_result" f)))
    feed-context))

--- a/src/cayenne/api/v1/feed.clj
+++ b/src/cayenne/api/v1/feed.clj
@@ -163,7 +163,7 @@
                     with-source (assoc parsed
                                        :source
                                        (-> feed-context :provider provider-names))
-                    doi (first (get-item-ids parsed :long-doi))]
+                    doi (first (itree/get-item-ids parsed :long-doi))]
                 (feed-log (filename) (str "parsed file for DOI:" doi))
                    (solr/insert-item with-source))]
        (xml/process-xml rdr "crossref_result" f)))

--- a/src/cayenne/api/v1/feed.clj
+++ b/src/cayenne/api/v1/feed.clj
@@ -166,7 +166,7 @@
                                        :source
                                        (-> feed-context :provider provider-names))
                     doi (first (itree/get-item-ids parsed :long-doi))]
-                   (feed-log (filename) (str "parsed file for DOI:" doi))
+                   (feed-log filename (str "parsed file for DOI:" doi))
                    (solr/insert-item with-source))]
        (xml/process-xml rdr "crossref_result" f)))
    feed-context))


### PR DESCRIPTION
https://github.com/CrossRef/rest-api-doc/issues/419
feed api doesn't do much for logging, and where it does, doesn't include necessary information. 
Changes:
1. log what DOI was pushed to what file name
2. once unixsd file is parsed, write out the successful parse and DOI 
3. if a failure occurs within processing, log the failure and exception. 