### PR TITLE
Fix typo in corrective type mapping in transform.clj

### DIFF
--- a/src/cayenne/api/transform.clj
+++ b/src/cayenne/api/transform.clj
@@ -15,7 +15,7 @@
 (def csl-type
   {:journal-article :article-journal
    :book-chapter :chapter
-   :posted-conent :manuscript
+   :posted-content :manuscript
    :proceedings-article :paper-conference})
 
 (defmulti ->format :media-type)


### PR DESCRIPTION
This typo probably accounts for the behaviour noted by by @larsgw in https://github.com/CrossRef/rest-api-doc/issues/187#issuecomment-973042141.